### PR TITLE
Small maintenance

### DIFF
--- a/BF4Intel/build.gradle
+++ b/BF4Intel/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.6.1'
+        classpath 'com.android.tools.build:gradle:0.6.3'
     }
 }
 apply plugin: 'android'


### PR DESCRIPTION
AndroidStudio 0.3.7 requires now minimum 0.6.3 of Android Gradle Plugin
