### PR TITLE
Make soldier spinner aware of previous selection

### DIFF
--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/adapters/NavigationDrawerListAdapter.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/adapters/NavigationDrawerListAdapter.java
@@ -1,6 +1,7 @@
 package com.ninetwozero.bf4intel.ui.adapters;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
@@ -14,6 +15,7 @@ import android.widget.Spinner;
 import com.ninetwozero.bf4intel.R;
 import com.ninetwozero.bf4intel.base.adapter.BaseIntelAdapter;
 import com.ninetwozero.bf4intel.interfaces.ListRowElement;
+import com.ninetwozero.bf4intel.json.login.SummarizedSoldierStats;
 import com.ninetwozero.bf4intel.menu.ListRowType;
 import com.ninetwozero.bf4intel.menu.SimpleListRow;
 import com.ninetwozero.bf4intel.menu.SoldierSpinnerRow;
@@ -31,8 +33,11 @@ import static com.ninetwozero.bf4intel.menu.ListRowType.SIDE_REGULAR_CHILD;
 import static com.ninetwozero.bf4intel.menu.ListRowType.SIDE_SOLDIER;
 
 public class NavigationDrawerListAdapter extends BaseIntelAdapter<ListRowElement> {
+    final SharedPreferences preferences;
+
     public NavigationDrawerListAdapter(final Context context, final List<ListRowElement> items) {
         super(context, items);
+        preferences = PreferenceManager.getDefaultSharedPreferences(context);
     }
 
     @Override
@@ -89,26 +94,33 @@ public class NavigationDrawerListAdapter extends BaseIntelAdapter<ListRowElement
             final SoldierSpinnerRow row = (SoldierSpinnerRow) item;
             final SoldierSpinnerAdapter adapter = new SoldierSpinnerAdapter(context, row.getSoldierStats());
             final Spinner spinner = (Spinner) view.findViewById(R.id.spinner_soldier);
+            final long id = preferences.getLong(Keys.Menu.LATEST_PERSONA, 0);
 
             spinner.setAdapter(adapter);
             spinner.setOnItemSelectedListener(
                 new AdapterView.OnItemSelectedListener() {
                     @Override
                     public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                        PreferenceManager.getDefaultSharedPreferences(context).edit().putLong(
-                            Keys.Menu.LATEST_PERSONA,
-                            id
-                        ).commit();
+                        preferences.edit().putLong(Keys.Menu.LATEST_PERSONA, id).commit();
                         BusProvider.getInstance().post(new ActiveSoldierChangedEvent(id));
                     }
 
                     @Override
                     public void onNothingSelected(AdapterView<?> parent) {
-
                     }
                 }
             );
+            spinner.setSelection(getIndexForSoldierInList(id, row.getSoldierStats()));
         }
+    }
+
+    private int getIndexForSoldierInList(final long id, final List<SummarizedSoldierStats> soldierStats) {
+        for (int i = 0, max = soldierStats.size(); i < max; i++) {
+            if (soldierStats.get(i).getId() == id) {
+                return i;
+            }
+        }
+        return 0;
     }
 
     private void populateSpecialLayouts(final View view, final ListRowElement item) {


### PR DESCRIPTION
@peter-budo:

Just a quick fix for something I noticed while browsing my user. :-)

How to try it:
Search for ninetwozero
See that Xbox player is selected
Turn off app
Start app
See that Xbox player is selected
Select PC player
Turn off app
Start app
See that PC player is selected

:-)
