### PR TITLE
Reload menu + active fragment upon user selection

### DIFF
--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/adapters/NavigationDrawerListAdapter.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/adapters/NavigationDrawerListAdapter.java
@@ -101,8 +101,11 @@ public class NavigationDrawerListAdapter extends BaseIntelAdapter<ListRowElement
                 new AdapterView.OnItemSelectedListener() {
                     @Override
                     public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                        preferences.edit().putLong(Keys.Menu.LATEST_PERSONA, id).commit();
-                        BusProvider.getInstance().post(new ActiveSoldierChangedEvent(id));
+                        final long oldId = preferences.getLong(Keys.Menu.LATEST_PERSONA, -1);
+                        if (oldId != id) {
+                            preferences.edit().putLong(Keys.Menu.LATEST_PERSONA, id).commit();
+                            BusProvider.getInstance().post(new ActiveSoldierChangedEvent(id));
+                        }
                     }
 
                     @Override

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/adapters/NavigationDrawerListAdapter.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/adapters/NavigationDrawerListAdapter.java
@@ -100,11 +100,11 @@ public class NavigationDrawerListAdapter extends BaseIntelAdapter<ListRowElement
             spinner.setOnItemSelectedListener(
                 new AdapterView.OnItemSelectedListener() {
                     @Override
-                    public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                        final long oldId = preferences.getLong(Keys.Menu.LATEST_PERSONA, -1);
-                        if (oldId != id) {
-                            preferences.edit().putLong(Keys.Menu.LATEST_PERSONA, id).commit();
-                            BusProvider.getInstance().post(new ActiveSoldierChangedEvent(id));
+                    public void onItemSelected(AdapterView<?> parent, View view, int position, long selectedId) {
+                        final long currentId = preferences.getLong(Keys.Menu.LATEST_PERSONA, -1);
+                        if (currentId != selectedId) {
+                            preferences.edit().putLong(Keys.Menu.LATEST_PERSONA, selectedId).commit();
+                            BusProvider.getInstance().post(new ActiveSoldierChangedEvent(selectedId));
                         }
                     }
 

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/fragments/NavigationDrawerFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/fragments/NavigationDrawerFragment.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -27,6 +26,7 @@ import com.ninetwozero.bf4intel.menu.ListRowType;
 import com.ninetwozero.bf4intel.menu.SimpleListRow;
 import com.ninetwozero.bf4intel.resources.Keys;
 import com.ninetwozero.bf4intel.ui.adapters.NavigationDrawerListAdapter;
+import com.ninetwozero.bf4intel.ui.datatypes.ActiveSoldierChangedEvent;
 import com.ninetwozero.bf4intel.utils.BusProvider;
 import com.ninetwozero.bf4intel.utils.ExternalAppLauncher;
 import com.squareup.otto.Subscribe;
@@ -114,8 +114,21 @@ public class NavigationDrawerFragment extends BaseListFragment {
         if (view == null) {
             return;
         }
+
         setupRegularViews(view);
         ((NavigationDrawerListAdapter) getListAdapter()).setItems(getItemsForMenu());
+    }
+
+    @Subscribe
+    public void onActiveSoldierChanged(final ActiveSoldierChangedEvent event) {
+        final View view = getView();
+        if (view == null) {
+            return;
+        }
+
+        final int position = getCheckedItemPosition();
+        ((NavigationDrawerListAdapter) getListAdapter()).setItems(getItemsForMenu());
+        selectItemFromState(position);
     }
 
     private void initialize(final View view) {
@@ -322,13 +335,15 @@ public class NavigationDrawerFragment extends BaseListFragment {
 
     private void selectItemFromState(final int position) {
         final NavigationDrawerListAdapter adapter = (NavigationDrawerListAdapter) getListAdapter();
-        if (position >= adapter.getCount()) {
-            selectItemFromState(fetchStartingPositionForSessionState());
+        int actualPosition = position;
+
+        if (position >= adapter.getCount() || position == ListView.INVALID_POSITION) {
+            actualPosition = fetchStartingPositionForSessionState();
         }
 
-        final ListRowElement row = adapter.getItem(position);
+        final ListRowElement row = adapter.getItem(actualPosition);
         if (row instanceof SimpleListRow) {
-            selectItem((SimpleListRow) row, position, true, true);
+            selectItem((SimpleListRow) row, actualPosition, true, true);
         }
     }
 
@@ -353,12 +368,7 @@ public class NavigationDrawerFragment extends BaseListFragment {
             try {
                 final FragmentTransaction transaction = fragmentManager.beginTransaction();
                 final String tag = item.getFragmentType().toString();
-                final Fragment fragment = fragmentManager.findFragmentByTag(tag);
-                if (fragment == null) {
-                    transaction.replace(R.id.activity_root, FragmentFactory.get(item.getFragmentType(), item.getData()), tag);
-                } else {
-                    transaction.show(fragment);
-                }
+                transaction.replace(R.id.activity_root, FragmentFactory.get(item.getFragmentType(), item.getData()), tag);
                 transaction.commit();
             } catch (TypeNotPresentException ex) {
                 showToast(ex.getMessage());


### PR DESCRIPTION
This fixes the bug where the fragment isn't reloaded to display the new user that's selected. Also makes sure we handle switching between multiple soldiers in one account and not just ignore it.

@peter-budo 

First search for ninetwozero, try toggling between both soldiers a few times (and notice current fragment reloading). Then try to search for LittleBoySVK, and notice that it reloads the fragment when returning from the search.
