### PR TITLE
Vehicle sorting effciency

### DIFF
--- a/core/src/main/java/com/ninetwozero/bf4intel/json/stats/vehicles/GroupedVehicleStats.java
+++ b/core/src/main/java/com/ninetwozero/bf4intel/json/stats/vehicles/GroupedVehicleStats.java
@@ -7,9 +7,9 @@ public class GroupedVehicleStats implements Comparable<GroupedVehicleStats> {
     private final String groupName;
     private final int serviceStarsCount;
     private final int serviceStarProgress;
-    private final int killCount;
-    private final long timeInVehicle;
-    private final List<VehicleStats> vehicleList;
+    private int killCount;
+    private long timeInVehicle;
+    private List<VehicleStats> vehicleList;
 
     public GroupedVehicleStats(String groupName, int serviceStarsCount, int serviceStarProgress, int killCount,
                                long timeInVehicle, List<VehicleStats> vehicleList) {
@@ -43,6 +43,12 @@ public class GroupedVehicleStats implements Comparable<GroupedVehicleStats> {
 
     public List<VehicleStats> getVehicleList() {
         return vehicleList;
+    }
+
+    public void addVehicleStats(VehicleStats stat) {
+        killCount += stat.getKillsCount();
+        timeInVehicle += stat.getTimeInVehicle();
+        vehicleList.add(stat);
     }
 
     @Override

--- a/core/src/main/java/com/ninetwozero/bf4intel/json/stats/vehicles/VehicleStatistics.java
+++ b/core/src/main/java/com/ninetwozero/bf4intel/json/stats/vehicles/VehicleStatistics.java
@@ -25,15 +25,8 @@ public class VehicleStatistics {
         GroupedVehicleStats group;
         for (VehicleStats stat : loaderVehicleList) {
             if (vehicleGroupsMap.containsKey(stat.getVehicleGroup())) {
-                GroupedVehicleStats temp = vehicleGroupsMap.get(stat.getVehicleGroup());
-                List<VehicleStats> vehicleStats = new ArrayList<VehicleStats>(temp.getVehicleList());
-                vehicleStats.add(stat);
-                group = new GroupedVehicleStats(temp.getGroupName(),
-                    temp.getServiceStarsCount(),
-                    temp.getServiceStarProgress(),
-                    temp.getKillCount() + stat.getKillsCount(),
-                    temp.getTimeInVehicle() + stat.getTimeInVehicle(),
-                    vehicleStats);
+                group = vehicleGroupsMap.get(stat.getVehicleGroup());
+                group.addVehicleStats(stat);
 
             } else {
                 List<VehicleStats> vehicleStats = new ArrayList<VehicleStats>();

--- a/core/src/test/java/com/ninetwozero/bf4intel/json/stats/vehicles/VehicleStatisticsTest.java
+++ b/core/src/test/java/com/ninetwozero/bf4intel/json/stats/vehicles/VehicleStatisticsTest.java
@@ -2,10 +2,10 @@ package com.ninetwozero.bf4intel.json.stats.vehicles;
 
 import com.ninetwozero.bf4intel.util.IntelJsonParser;
 
+import org.junit.Test;
+
 import java.io.IOException;
 import java.util.List;
-
-import org.junit.Test;
 
 import static junit.framework.Assert.assertEquals;
 


### PR DESCRIPTION
Improved vehicles stats sorting efficiency. After fixing total this was result on 5 runs I did 

```
com.ninetwozero.bf4intel.json.stats.vehicles.VehicleStatisticsTest > should_parse_multiple_times_refactored STANDARD_OUT
    Average time = 14

com.ninetwozero.bf4intel.json.stats.vehicles.VehicleStatisticsTest > should_parse_multiple_times STANDARD_OUT
    Average time = 6
```
