### PR TITLE
Fixed ghost 2 assignment progress bar

### DIFF
--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/assignments/AssignmentsAdapter.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/assignments/AssignmentsAdapter.java
@@ -69,8 +69,8 @@ public class AssignmentsAdapter extends BaseIntelAdapter<Assignment> {
         imagePrerequisite.setVisibility(View.INVISIBLE);
 
         final ProgressBar completionProgress = (ProgressBar) view.findViewById(R.id.assignment_completion);
-        completionProgress.setProgress(assignment.getCompletion());
         completionProgress.setMax(100);
+        completionProgress.setProgress(assignment.getCompletion());
         completionProgress.setVisibility(View.VISIBLE);
     }
 


### PR DESCRIPTION
@karllindmark 

This is fixed now. However I do remember fixing this order of progress bar calls already once in past so I'm surprised that it happen again.
