### PR TITLE
Fix database related crashes

### DIFF
--- a/BF4Intel/build.gradle
+++ b/BF4Intel/build.gradle
@@ -15,6 +15,9 @@ repositories {
     maven {
         url "http://www.bugsense.com/gradle/"
     }
+    maven {
+        url "http://oss.sonatype.org/content/repositories/snapshots/"
+    }
 }
 
 android {
@@ -68,7 +71,7 @@ dependencies {
             'com.squareup:otto:1.3.4',
             'com.google.code.gson:gson:2.2.4',
             'com.squareup.picasso:picasso:2.1.1',
-            'se.emilsjolander:sprinkles:1.2.4',
+            'se.emilsjolander:sprinkles:1.3.0-SNAPSHOT',
             'com.astuetz:pagerslidingtabstrip:1.0.1',
             'com.bugsense.trace:bugsense:3.6.1',
             'se.emilsjolander:stickylistheaders:2.2.0'

--- a/BF4Intel/src/main/AndroidManifest.xml
+++ b/BF4Intel/src/main/AndroidManifest.xml
@@ -174,6 +174,25 @@
       android:label="@string/label_service_awards"
       />
 
+    <!-- News -->
+
+    <service
+      android:name=".services.news.NewsListingService"
+      android:label="@string/label_service_news"
+      />
+
+    <service
+      android:name=".services.news.NewsArticleService"
+      android:label="@string/label_service_news"
+      />
+
+    <!-- Battle feed -->
+
+    <service
+      android:name=".services.battlefeed.BattleFeedService"
+      android:label="@string/label_service_battlefeed"
+      />
+
   </application>
 
 </manifest>

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/Bf4Intel.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/Bf4Intel.java
@@ -26,6 +26,8 @@ import com.ninetwozero.bf4intel.dao.unlocks.vehicles.SortedVehicleUnlocksSeriali
 import com.ninetwozero.bf4intel.dao.unlocks.vehicles.VehicleUnlockDAO;
 import com.ninetwozero.bf4intel.dao.unlocks.weapons.SortedWeaponUnlocksSerializer;
 import com.ninetwozero.bf4intel.dao.unlocks.weapons.WeaponUnlockDAO;
+import com.ninetwozero.bf4intel.database.migrations.InitialMigration;
+import com.ninetwozero.bf4intel.database.migrations.Version095Migration;
 import com.ninetwozero.bf4intel.json.assignments.SortedAssignmentContainer;
 import com.ninetwozero.bf4intel.json.awards.SortedAwardContainer;
 import com.ninetwozero.bf4intel.json.soldieroverview.SoldierOverview;
@@ -74,32 +76,8 @@ public class Bf4Intel extends Application {
     }
 
     private void setupMigrations(Sprinkles sprinkles) {
-        sprinkles.addMigration(getInitialMigration());
-        sprinkles.addMigration(getMigrationToVersion_0_9_6());
-    }
-
-    private Migration getMigrationToVersion_0_9_6() {
-        Migration migration = new Migration();
-        migration.createTable(WeaponStatsDAO.class);
-        migration.createTable(VehicleStatsDAO.class);
-        //migration.createTable(BattleReportDAO.class);
-        migration.createTable(DetailedStatsDAO.class);
-
-        migration.createTable(WeaponUnlockDAO.class);
-        migration.createTable(VehicleUnlockDAO.class);
-        migration.createTable(KitUnlockDAO.class);
-
-        migration.createTable(AssignmentsDAO.class);
-        migration.createTable(AwardsDAO.class);
-        return migration;
-    }
-
-    private Migration getInitialMigration() {
-        Migration migration = new Migration();
-        migration.createTable(SummarizedSoldierStatsDAO.class);
-        migration.createTable(ProfileDAO.class);
-        migration.createTable(SoldierOverviewDAO.class);
-        return migration;
+        sprinkles.addMigration(new InitialMigration());
+        sprinkles.addMigration(new Version095Migration());
     }
 
     public static RequestQueue getRequestQueue() {

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/base/ui/BaseLoadingFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/base/ui/BaseLoadingFragment.java
@@ -24,7 +24,6 @@ import com.squareup.otto.Subscribe;
 public abstract class BaseLoadingFragment extends BaseFragment implements Response.ErrorListener {
     protected final Gson gson = GsonProvider.getInstance();
     protected final JsonParser parser = new JsonParser();
-    protected RequestQueue requestQueue;
 
     protected boolean isReloading;
 
@@ -32,7 +31,6 @@ public abstract class BaseLoadingFragment extends BaseFragment implements Respon
     public void onCreate(final Bundle icicle) {
         super.onCreate(icicle);
         setHasOptionsMenu(true);
-        requestQueue = Volley.newRequestQueue(getActivity());
     }
 
     @Override
@@ -46,19 +44,6 @@ public abstract class BaseLoadingFragment extends BaseFragment implements Respon
     public void onPause() {
         super.onPause();
         BusProvider.getInstance().unregister(this);
-    }
-
-    @Override
-    public void onStop(){
-        requestQueue.cancelAll(
-            new RequestQueue.RequestFilter() {
-                @Override
-                public boolean apply(Request<?> request) {
-                    return request.getMethod() == Request.Method.GET;
-                }
-            }
-        );
-        super.onStop();
     }
 
     @Override

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/base/ui/BaseLoadingFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/base/ui/BaseLoadingFragment.java
@@ -22,28 +22,42 @@ import com.ninetwozero.bf4intel.utils.NumberFormatter;
 import com.squareup.otto.Subscribe;
 
 public abstract class BaseLoadingFragment extends BaseFragment implements Response.ErrorListener {
+    private static final String STATE_ROTATED = "stateRotated";
+
     protected final Gson gson = GsonProvider.getInstance();
     protected final JsonParser parser = new JsonParser();
 
     protected boolean isReloading;
+    protected boolean hasChangedOrientation;
 
     @Override
     public void onCreate(final Bundle icicle) {
         super.onCreate(icicle);
         setHasOptionsMenu(true);
+        hasChangedOrientation = icicle == null ? false : icicle.getBoolean(STATE_ROTATED, false);
     }
 
     @Override
     public void onResume() {
         super.onResume();
         BusProvider.getInstance().register(this);
-        startLoadingData();
+
+        if (!hasChangedOrientation) {
+            startLoadingData();
+        }
     }
 
     @Override
     public void onPause() {
         super.onPause();
         BusProvider.getInstance().unregister(this);
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        outState.putBoolean(STATE_ROTATED, getActivity().isChangingConfigurations());
     }
 
     @Override

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/base/ui/BaseLoadingIntelActivity.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/base/ui/BaseLoadingIntelActivity.java
@@ -19,30 +19,15 @@ import com.ninetwozero.bf4intel.factories.GsonProvider;
 
 public abstract class BaseLoadingIntelActivity extends BaseIntelActivity implements Response.ErrorListener {
     protected final Gson gson = GsonProvider.getInstance();
-    protected RequestQueue requestQueue;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        requestQueue = Volley.newRequestQueue(this);
     }
 
     @Override
     public void onErrorResponse(final VolleyError error) {
         Log.w(getClass().getSimpleName(), "[onLoadFailure] " + error.getMessage());
-    }
-
-    @Override
-    public void onStop(){
-        requestQueue.cancelAll(
-            new RequestQueue.RequestFilter() {
-                @Override
-                public boolean apply(Request<?> request) {
-                    return request.getMethod() == Request.Method.GET;
-                }
-            }
-        );
-        super.onStop();
     }
 
     public JsonObject extractFromJson(String json) {

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/base/ui/BaseLoadingListFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/base/ui/BaseLoadingListFragment.java
@@ -21,26 +21,40 @@ import com.ninetwozero.bf4intel.utils.BusProvider;
 import com.squareup.otto.Subscribe;
 
 public abstract class BaseLoadingListFragment extends BaseListFragment implements Response.ErrorListener {
+    private static final String STATE_ROTATED = "stateRotated";
+
     protected Gson gson = GsonProvider.getInstance();
     protected boolean isReloading;
+    protected boolean hasChangedOrientation;
 
     @Override
     public void onCreate(final Bundle icicle) {
         super.onCreate(icicle);
         setHasOptionsMenu(true);
+        hasChangedOrientation = icicle == null ? false : icicle.getBoolean(STATE_ROTATED, false);
     }
 
     @Override
     public void onResume() {
         super.onResume();
         BusProvider.getInstance().register(this);
-        startLoadingData();
+
+        if (!hasChangedOrientation) {
+            startLoadingData();
+        }
     }
 
     @Override
     public void onPause() {
         super.onPause();
         BusProvider.getInstance().unregister(this);
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        outState.putBoolean(STATE_ROTATED, getActivity().isChangingConfigurations());
     }
 
     @Override

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/base/ui/BaseLoadingListFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/base/ui/BaseLoadingListFragment.java
@@ -23,13 +23,11 @@ import com.squareup.otto.Subscribe;
 public abstract class BaseLoadingListFragment extends BaseListFragment implements Response.ErrorListener {
     protected Gson gson = GsonProvider.getInstance();
     protected boolean isReloading;
-    protected RequestQueue requestQueue;
 
     @Override
     public void onCreate(final Bundle icicle) {
         super.onCreate(icicle);
         setHasOptionsMenu(true);
-        requestQueue = Volley.newRequestQueue(getActivity());
     }
 
     @Override
@@ -43,19 +41,6 @@ public abstract class BaseLoadingListFragment extends BaseListFragment implement
     public void onPause() {
         super.onPause();
         BusProvider.getInstance().unregister(this);
-    }
-
-    @Override
-    public void onStop(){
-        requestQueue.cancelAll(
-            new RequestQueue.RequestFilter() {
-                @Override
-                public boolean apply(Request<?> request) {
-                    return request.getMethod() == Request.Method.GET;
-                }
-            }
-        );
-        super.onStop();
     }
 
     @Override

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/dao/ProfileDAO.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/dao/ProfileDAO.java
@@ -4,7 +4,7 @@ import com.ninetwozero.bf4intel.json.Profile;
 
 import se.emilsjolander.sprinkles.Model;
 import se.emilsjolander.sprinkles.annotations.Column;
-import se.emilsjolander.sprinkles.annotations.PrimaryKey;
+import se.emilsjolander.sprinkles.annotations.Key;
 import se.emilsjolander.sprinkles.annotations.Table;
 
 
@@ -12,7 +12,7 @@ import se.emilsjolander.sprinkles.annotations.Table;
 public class ProfileDAO extends Model {
     public static final String TABLE_NAME = "UserProfile";
 
-    @PrimaryKey
+    @Key
     @Column("userId")
     private String userId;
 

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/dao/assignments/AssignmentsDAO.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/dao/assignments/AssignmentsDAO.java
@@ -5,21 +5,21 @@ import com.ninetwozero.bf4intel.json.assignments.SortedAssignmentContainer;
 
 import se.emilsjolander.sprinkles.Model;
 import se.emilsjolander.sprinkles.annotations.Column;
-import se.emilsjolander.sprinkles.annotations.PrimaryKey;
+import se.emilsjolander.sprinkles.annotations.Key;
 import se.emilsjolander.sprinkles.annotations.Table;
 
 @Table("SoldierAssignments")
 public class AssignmentsDAO extends Model {
     public static final String TABLE_NAME = "SoldierAssignments";
 
-    @PrimaryKey
+    @Key
     @Column("soldierId")
     private String soldierId;
 
     @Column("soldierName")
     private String soldierName;
 
-    @PrimaryKey
+    @Key
     @Column("platformId")
     private int platformId;
 

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/dao/awards/AwardsDAO.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/dao/awards/AwardsDAO.java
@@ -5,21 +5,21 @@ import com.ninetwozero.bf4intel.json.awards.SortedAwardContainer;
 
 import se.emilsjolander.sprinkles.Model;
 import se.emilsjolander.sprinkles.annotations.Column;
-import se.emilsjolander.sprinkles.annotations.PrimaryKey;
+import se.emilsjolander.sprinkles.annotations.Key;
 import se.emilsjolander.sprinkles.annotations.Table;
 
 @Table("SoldierAwards")
 public class AwardsDAO extends Model {
     public static final String TABLE_NAME = "SoldierAwards";
 
-    @PrimaryKey
+    @Key
     @Column("soldierId")
     private String soldierId;
 
     @Column("soldierName")
     private String soldierName;
 
-    @PrimaryKey
+    @Key
     @Column("platformId")
     private int platformId;
 

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/dao/login/SummarizedSoldierStatsDAO.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/dao/login/SummarizedSoldierStatsDAO.java
@@ -3,7 +3,7 @@ package com.ninetwozero.bf4intel.dao.login;
 import com.ninetwozero.bf4intel.json.login.SummarizedSoldierStats;
 
 import se.emilsjolander.sprinkles.Model;
-import se.emilsjolander.sprinkles.annotations.AutoIncrementPrimaryKey;
+import se.emilsjolander.sprinkles.annotations.AutoIncrementKey;
 import se.emilsjolander.sprinkles.annotations.Column;
 import se.emilsjolander.sprinkles.annotations.Table;
 
@@ -12,7 +12,7 @@ import se.emilsjolander.sprinkles.annotations.Table;
 public class SummarizedSoldierStatsDAO extends Model {
     public static final String TABLE_NAME = "UserSoldier";
 
-    @AutoIncrementPrimaryKey
+    @AutoIncrementKey
     @Column("rowId")
     private long id;
 

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/dao/soldieroverview/SoldierOverviewDAO.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/dao/soldieroverview/SoldierOverviewDAO.java
@@ -5,21 +5,21 @@ import com.ninetwozero.bf4intel.json.soldieroverview.SoldierOverview;
 
 import se.emilsjolander.sprinkles.Model;
 import se.emilsjolander.sprinkles.annotations.Column;
-import se.emilsjolander.sprinkles.annotations.PrimaryKey;
+import se.emilsjolander.sprinkles.annotations.Key;
 import se.emilsjolander.sprinkles.annotations.Table;
 
 @Table("SoldierOverview")
 public class SoldierOverviewDAO extends Model {
     public static final String TABLE_NAME = "SoldierOverview";
 
-    @PrimaryKey
+    @Key
     @Column("soldierId")
     private String soldierId;
 
     @Column("soldierName")
     private String soldierName;
 
-    @PrimaryKey
+    @Key
     @Column("platformId")
     private int platformId;
 

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/dao/stats/details/DetailedStatsDAO.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/dao/stats/details/DetailedStatsDAO.java
@@ -5,21 +5,21 @@ import com.ninetwozero.bf4intel.json.stats.details.DetailedStatsContainer;
 
 import se.emilsjolander.sprinkles.Model;
 import se.emilsjolander.sprinkles.annotations.Column;
-import se.emilsjolander.sprinkles.annotations.PrimaryKey;
+import se.emilsjolander.sprinkles.annotations.Key;
 import se.emilsjolander.sprinkles.annotations.Table;
 
 @Table("SoldierDetailedStatistics")
 public class DetailedStatsDAO extends Model {
     public static final String TABLE_NAME = "SoldierDetailedStatistics";
 
-    @PrimaryKey
+    @Key
     @Column("soldierId")
     private String soldierId;
 
     @Column("soldierName")
     private String soldierName;
 
-    @PrimaryKey
+    @Key
     @Column("platformId")
     private int platformId;
 

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/dao/stats/vehicles/VehicleStatsDAO.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/dao/stats/vehicles/VehicleStatsDAO.java
@@ -5,21 +5,21 @@ import com.ninetwozero.bf4intel.json.stats.vehicles.GroupedVehicleStatsContainer
 
 import se.emilsjolander.sprinkles.Model;
 import se.emilsjolander.sprinkles.annotations.Column;
-import se.emilsjolander.sprinkles.annotations.PrimaryKey;
+import se.emilsjolander.sprinkles.annotations.Key;
 import se.emilsjolander.sprinkles.annotations.Table;
 
 @Table("SoldierVehicleStatistics")
 public class VehicleStatsDAO extends Model {
     public static final String TABLE_NAME = "SoldierVehicleStatistics";
 
-    @PrimaryKey
+    @Key
     @Column("soldierId")
     private String soldierId;
 
     @Column("soldierName")
     private String soldierName;
 
-    @PrimaryKey
+    @Key
     @Column("platformId")
     private int platformId;
 

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/dao/stats/weapons/WeaponStatsDAO.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/dao/stats/weapons/WeaponStatsDAO.java
@@ -5,21 +5,21 @@ import com.ninetwozero.bf4intel.json.stats.weapons.WeaponStatistics;
 
 import se.emilsjolander.sprinkles.Model;
 import se.emilsjolander.sprinkles.annotations.Column;
-import se.emilsjolander.sprinkles.annotations.PrimaryKey;
+import se.emilsjolander.sprinkles.annotations.Key;
 import se.emilsjolander.sprinkles.annotations.Table;
 
 @Table("SoldierWeaponStatistics")
 public class WeaponStatsDAO extends Model {
     public static final String TABLE_NAME = "SoldierWeaponStatistics";
 
-    @PrimaryKey
+    @Key
     @Column("soldierId")
     private String soldierId;
 
     @Column("soldierName")
     private String soldierName;
 
-    @PrimaryKey
+    @Key
     @Column("platformId")
     private int platformId;
 

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/dao/unlocks/kits/KitUnlockDAO.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/dao/unlocks/kits/KitUnlockDAO.java
@@ -5,21 +5,21 @@ import com.ninetwozero.bf4intel.json.unlocks.kits.SortedKitUnlocks;
 
 import se.emilsjolander.sprinkles.Model;
 import se.emilsjolander.sprinkles.annotations.Column;
-import se.emilsjolander.sprinkles.annotations.PrimaryKey;
+import se.emilsjolander.sprinkles.annotations.Key;
 import se.emilsjolander.sprinkles.annotations.Table;
 
 @Table("SoldierKitUnlocks")
 public class KitUnlockDAO extends Model {
     public static final String TABLE_NAME = "SoldierKitUnlocks";
 
-    @PrimaryKey
+    @Key
     @Column("soldierId")
     private String soldierId;
 
     @Column("soldierName")
     private String soldierName;
 
-    @PrimaryKey
+    @Key
     @Column("platformId")
     private int platformId;
 

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/dao/unlocks/vehicles/VehicleUnlockDAO.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/dao/unlocks/vehicles/VehicleUnlockDAO.java
@@ -5,21 +5,21 @@ import com.ninetwozero.bf4intel.json.unlocks.vehicles.SortedVehicleUnlocks;
 
 import se.emilsjolander.sprinkles.Model;
 import se.emilsjolander.sprinkles.annotations.Column;
-import se.emilsjolander.sprinkles.annotations.PrimaryKey;
+import se.emilsjolander.sprinkles.annotations.Key;
 import se.emilsjolander.sprinkles.annotations.Table;
 
 @Table("SoldierVehicleUnlocks")
 public class VehicleUnlockDAO extends Model {
     public static final String TABLE_NAME = "SoldierVehicleUnlocks";
 
-    @PrimaryKey
+    @Key
     @Column("soldierId")
     private String soldierId;
 
     @Column("soldierName")
     private String soldierName;
 
-    @PrimaryKey
+    @Key
     @Column("platformId")
     private int platformId;
 

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/dao/unlocks/weapons/WeaponUnlockDAO.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/dao/unlocks/weapons/WeaponUnlockDAO.java
@@ -5,21 +5,21 @@ import com.ninetwozero.bf4intel.json.unlocks.weapons.SortedWeaponUnlocks;
 
 import se.emilsjolander.sprinkles.Model;
 import se.emilsjolander.sprinkles.annotations.Column;
-import se.emilsjolander.sprinkles.annotations.PrimaryKey;
+import se.emilsjolander.sprinkles.annotations.Key;
 import se.emilsjolander.sprinkles.annotations.Table;
 
 @Table("SoldierWeaponUnlocks")
 public class WeaponUnlockDAO extends Model {
     public static final String TABLE_NAME = "SoldierWeaponUnlocks";
 
-    @PrimaryKey
+    @Key
     @Column("soldierId")
     private String soldierId;
 
     @Column("soldierName")
     private String soldierName;
 
-    @PrimaryKey
+    @Key
     @Column("platformId")
     private int platformId;
 

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/database/migrations/InitialMigration.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/database/migrations/InitialMigration.java
@@ -1,0 +1,58 @@
+package com.ninetwozero.bf4intel.database.migrations;
+
+import android.database.sqlite.SQLiteDatabase;
+
+import com.ninetwozero.bf4intel.dao.ProfileDAO;
+import com.ninetwozero.bf4intel.dao.login.SummarizedSoldierStatsDAO;
+import com.ninetwozero.bf4intel.dao.soldieroverview.SoldierOverviewDAO;
+import com.ninetwozero.bf4intel.json.login.SummarizedSoldierStats;
+
+import se.emilsjolander.sprinkles.Migration;
+
+public class InitialMigration extends Migration {
+    @Override
+    protected void doMigration(SQLiteDatabase database) {
+        createSummarizedSoldierStatsTable(database);
+        createProfileTable(database);
+        createSoldierOverviewTable(database);
+    }
+
+    private void createSummarizedSoldierStatsTable(SQLiteDatabase database) {
+        database.execSQL(
+            "CREATE TABLE " + SummarizedSoldierStatsDAO.TABLE_NAME + "(" +
+                "rowId INTEGER PRIMARY KEY AUTOINCREMENT," +
+                "soldierId TEXT," +
+                "soldierName TEXT," +
+                "tag TEXT," +
+                "picture TEXT," +
+                "userId TEXT," +
+                "rank INTEGER," +
+                "platform INTEGER," +
+                "game INTEGER," +
+            ")"
+        );
+    }
+
+    private void createProfileTable(SQLiteDatabase database) {
+        database.execSQL(
+            "CREATE TABLE " + ProfileDAO.TABLE_NAME + "(" +
+                "userId TEXT PRIMARY KEY," +
+                "username TEXT," +
+                "gravatarMd5 TEXT" +
+            ")"
+        );
+    }
+
+    private void createSoldierOverviewTable(SQLiteDatabase database) {
+        database.execSQL(
+            "CREATE TABLE " + SoldierOverviewDAO.TABLE_NAME + "(" +
+                "soldierId TEXT," +
+                "soldierName TEXT," +
+                "platformId INTEGER" +
+                "json TEXT," +
+                "version INTEGER," +
+                "PRIMARY KEY(soldierId, platformId)" +
+            ")"
+        );
+    }
+}

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/database/migrations/InitialMigration.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/database/migrations/InitialMigration.java
@@ -5,7 +5,6 @@ import android.database.sqlite.SQLiteDatabase;
 import com.ninetwozero.bf4intel.dao.ProfileDAO;
 import com.ninetwozero.bf4intel.dao.login.SummarizedSoldierStatsDAO;
 import com.ninetwozero.bf4intel.dao.soldieroverview.SoldierOverviewDAO;
-import com.ninetwozero.bf4intel.json.login.SummarizedSoldierStats;
 
 import se.emilsjolander.sprinkles.Migration;
 
@@ -28,7 +27,7 @@ public class InitialMigration extends Migration {
                 "userId TEXT," +
                 "rank INTEGER," +
                 "platform INTEGER," +
-                "game INTEGER," +
+                "game INTEGER" +
             ")"
         );
     }
@@ -48,7 +47,7 @@ public class InitialMigration extends Migration {
             "CREATE TABLE " + SoldierOverviewDAO.TABLE_NAME + "(" +
                 "soldierId TEXT," +
                 "soldierName TEXT," +
-                "platformId INTEGER" +
+                "platformId INTEGER," +
                 "json TEXT," +
                 "version INTEGER," +
                 "PRIMARY KEY(soldierId, platformId)" +

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/database/migrations/Version095Migration.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/database/migrations/Version095Migration.java
@@ -1,0 +1,45 @@
+package com.ninetwozero.bf4intel.database.migrations;
+
+import android.database.sqlite.SQLiteDatabase;
+
+
+import com.ninetwozero.bf4intel.dao.assignments.AssignmentsDAO;
+import com.ninetwozero.bf4intel.dao.awards.AwardsDAO;
+import com.ninetwozero.bf4intel.dao.stats.details.DetailedStatsDAO;
+import com.ninetwozero.bf4intel.dao.stats.vehicles.VehicleStatsDAO;
+import com.ninetwozero.bf4intel.dao.stats.weapons.WeaponStatsDAO;
+import com.ninetwozero.bf4intel.dao.unlocks.kits.KitUnlockDAO;
+import com.ninetwozero.bf4intel.dao.unlocks.vehicles.VehicleUnlockDAO;
+import com.ninetwozero.bf4intel.dao.unlocks.weapons.WeaponUnlockDAO;
+
+import se.emilsjolander.sprinkles.Migration;
+
+public class Version095Migration extends Migration {
+    @Override
+    protected void doMigration(SQLiteDatabase database) {
+        createRegularJsonTable(database, WeaponStatsDAO.TABLE_NAME);
+        createRegularJsonTable(database, VehicleStatsDAO.TABLE_NAME);
+        //createRegularJsonTable(database, BattleReportDAO.TABLE_NAME);
+        createRegularJsonTable(database, DetailedStatsDAO.TABLE_NAME);
+
+        createRegularJsonTable(database, WeaponUnlockDAO.TABLE_NAME);
+        createRegularJsonTable(database, VehicleUnlockDAO.TABLE_NAME);
+        createRegularJsonTable(database, KitUnlockDAO.TABLE_NAME);
+
+        createRegularJsonTable(database, AssignmentsDAO.TABLE_NAME);
+        createRegularJsonTable(database, AwardsDAO.TABLE_NAME);
+    }
+
+    private void createRegularJsonTable(SQLiteDatabase database, String tableName) {
+        database.execSQL(
+            "CREATE TABLE " + tableName + "(" +
+                "soldierId TEXT," +
+                "soldierName TEXT," +
+                "platformId INTEGER" +
+                "json TEXT," +
+                "version INTEGER," +
+                "PRIMARY KEY(soldierId, platformId)" +
+                ")"
+        );
+    }
+}

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/database/migrations/Version095Migration.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/database/migrations/Version095Migration.java
@@ -35,7 +35,7 @@ public class Version095Migration extends Migration {
             "CREATE TABLE " + tableName + "(" +
                 "soldierId TEXT," +
                 "soldierName TEXT," +
-                "platformId INTEGER" +
+                "platformId INTEGER," +
                 "json TEXT," +
                 "version INTEGER," +
                 "PRIMARY KEY(soldierId, platformId)" +

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/events/battlefeed/BattleFeedRefreshedEvent.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/events/battlefeed/BattleFeedRefreshedEvent.java
@@ -1,0 +1,15 @@
+package com.ninetwozero.bf4intel.events.battlefeed;
+
+import com.ninetwozero.bf4intel.events.RefreshCompletedEvent;
+import com.ninetwozero.bf4intel.json.battlefeed.BattleFeed;
+
+public class BattleFeedRefreshedEvent {
+    private BattleFeed feed;
+    public BattleFeedRefreshedEvent(BattleFeed feed) {
+        this.feed = feed;
+    }
+
+    public BattleFeed getFeed() {
+        return feed;
+    }
+}

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/events/news/NewsArticleRefreshedEvent.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/events/news/NewsArticleRefreshedEvent.java
@@ -1,0 +1,15 @@
+package com.ninetwozero.bf4intel.events.news;
+
+import com.ninetwozero.bf4intel.json.news.NewsArticleRequest;
+
+public class NewsArticleRefreshedEvent {
+    private NewsArticleRequest request;
+
+    public NewsArticleRefreshedEvent(NewsArticleRequest request) {
+        this.request = request;
+    }
+
+    public NewsArticleRequest getRequest() {
+        return request;
+    }
+}

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/events/news/NewsListingRefreshedEvent.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/events/news/NewsListingRefreshedEvent.java
@@ -1,0 +1,16 @@
+package com.ninetwozero.bf4intel.events.news;
+
+
+import com.ninetwozero.bf4intel.json.news.NewsListRequest;
+
+public class NewsListingRefreshedEvent {
+    private NewsListRequest request;
+
+    public NewsListingRefreshedEvent(NewsListRequest request) {
+        this.request = request;
+    }
+
+    public NewsListRequest getRequest() {
+        return this.request;
+    }
+}

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/factories/UrlFactory.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/factories/UrlFactory.java
@@ -67,8 +67,8 @@ public class UrlFactory {
         return createURL(String.format(Locale.getDefault(), "feed/homeevents/?start=%d", offset));
     }
 
-    public static URL buildUserFeedURL(final long userId, final int offset) {
-        return createURL(String.format(Locale.getDefault(), "feed/profileevents/%d/?start=%d", userId, offset));
+    public static URL buildUserFeedURL(final String userId, final int offset) {
+        return createURL(String.format(Locale.getDefault(), "feed/profileevents/%s/?start=%d", userId, offset));
     }
 
     public static URL buildUserSearchURL() {

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/services/BaseApiService.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/services/BaseApiService.java
@@ -16,6 +16,7 @@ import com.ninetwozero.bf4intel.utils.BusProvider;
 public abstract class BaseApiService extends Service implements Response.ErrorListener {
     public static final String SOLDIER_BUNDLE = "soldierBundle";
 
+    protected int intentCount;
     protected Bundle soldier;
 
     private final Gson gson = GsonProvider.getInstance();
@@ -23,6 +24,8 @@ public abstract class BaseApiService extends Service implements Response.ErrorLi
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         soldier = intent.getBundleExtra(SOLDIER_BUNDLE);
+        intentCount++;
+
         return super.onStartCommand(intent, flags, startId);
     }
 

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/services/SoldierOverviewService.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/services/SoldierOverviewService.java
@@ -76,7 +76,7 @@ public class SoldierOverviewService extends BaseApiService {
                     protected void deliverResponse(Boolean result) {
                         BusProvider.getInstance().post(new SoldierInformationUpdatedEvent(soldier));
                         BusProvider.getInstance().post(new SoldierOverviewRefreshedEvent(result));
-                        stopSelf(startId);
+                        stopSelf();
                     }
                 }
             );

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/services/SoldierOverviewService.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/services/SoldierOverviewService.java
@@ -6,13 +6,13 @@ import android.content.Intent;
 import com.ninetwozero.bf4intel.Bf4Intel;
 import com.ninetwozero.bf4intel.dao.login.SummarizedSoldierStatsDAO;
 import com.ninetwozero.bf4intel.dao.soldieroverview.SoldierOverviewDAO;
+import com.ninetwozero.bf4intel.events.SoldierInformationUpdatedEvent;
+import com.ninetwozero.bf4intel.events.soldieroverview.SoldierOverviewRefreshedEvent;
 import com.ninetwozero.bf4intel.factories.UrlFactory;
 import com.ninetwozero.bf4intel.json.soldieroverview.SoldierOverview;
 import com.ninetwozero.bf4intel.network.SimpleGetRequest;
 import com.ninetwozero.bf4intel.resources.Keys;
 import com.ninetwozero.bf4intel.utils.BusProvider;
-import com.ninetwozero.bf4intel.events.SoldierInformationUpdatedEvent;
-import com.ninetwozero.bf4intel.events.soldieroverview.SoldierOverviewRefreshedEvent;
 
 import se.emilsjolander.sprinkles.Query;
 import se.emilsjolander.sprinkles.Transaction;
@@ -23,62 +23,64 @@ public class SoldierOverviewService extends BaseApiService {
     public int onStartCommand(final Intent intent, final int flags, final int startId) {
         super.onStartCommand(intent, flags, startId);
 
-        Bf4Intel.getRequestQueue().add(
-            new SimpleGetRequest<Boolean>(
-                UrlFactory.buildSoldierOverviewURL(
-                    soldier.getString(Keys.Soldier.ID, ""),
-                    soldier.getInt(Keys.Soldier.PLATFORM, 0)
-                ),
-                this
-            ) {
-                @Override
-                protected Boolean doParse(String json) {
-                    final Transaction transaction = new Transaction();
-                    final SoldierOverview soldierOverview = fromJson(json, SoldierOverview.class);
-                    boolean success = true;
+        if (intentCount == 1) {
+            Bf4Intel.getRequestQueue().add(
+                new SimpleGetRequest<Boolean>(
+                    UrlFactory.buildSoldierOverviewURL(
+                        soldier.getString(Keys.Soldier.ID, ""),
+                        soldier.getInt(Keys.Soldier.PLATFORM, 0)
+                    ),
+                    this
+                ) {
+                    @Override
+                    protected Boolean doParse(String json) {
+                        final Transaction transaction = new Transaction();
+                        final SoldierOverview soldierOverview = fromJson(json, SoldierOverview.class);
+                        boolean success = true;
 
-                    SoldierOverviewDAO overviewDao = new SoldierOverviewDAO(
-                        soldier.getString(Keys.Soldier.ID),
-                        soldier.getString(Keys.Soldier.NAME),
-                        soldier.getInt(Keys.Soldier.PLATFORM),
-                        soldierOverview
-                    );
+                        SoldierOverviewDAO overviewDao = new SoldierOverviewDAO(
+                            soldier.getString(Keys.Soldier.ID),
+                            soldier.getString(Keys.Soldier.NAME),
+                            soldier.getInt(Keys.Soldier.PLATFORM),
+                            soldierOverview
+                        );
 
-                    if (!overviewDao.save(transaction)) {
-                        success = false;
+                        if (!overviewDao.save(transaction)) {
+                            success = false;
+                        }
+
+                        SummarizedSoldierStatsDAO statsDao = Query.one(
+                            SummarizedSoldierStatsDAO.class,
+                            "SELECT * " +
+                                "FROM " + SummarizedSoldierStatsDAO.TABLE_NAME + " " +
+                                "WHERE soldierId = ? AND platform = ?",
+                            soldier.getString(Keys.Soldier.ID),
+                            soldier.getInt(Keys.Soldier.PLATFORM)
+                        ).get();
+
+                        statsDao.setRank(soldierOverview.getCurrentRank().getLevel());
+                        if (soldierOverview.getPersonaInfo() != null) {
+                            statsDao.setPicture(soldierOverview.getPersonaInfo().getPicture());
+                        }
+
+                        if (!statsDao.save(transaction)) {
+                            success = false;
+                        }
+
+                        transaction.setSuccessful(success);
+                        transaction.finish();
+                        return success;
                     }
 
-                    SummarizedSoldierStatsDAO statsDao = Query.one(
-                        SummarizedSoldierStatsDAO.class,
-                        "SELECT * " +
-                        "FROM " + SummarizedSoldierStatsDAO.TABLE_NAME + " " +
-                        "WHERE soldierId = ? AND platform = ?",
-                        soldier.getString(Keys.Soldier.ID),
-                        soldier.getInt(Keys.Soldier.PLATFORM)
-                    ).get();
-
-                    statsDao.setRank(soldierOverview.getCurrentRank().getLevel());
-                    if (soldierOverview.getPersonaInfo() != null) {
-                        statsDao.setPicture(soldierOverview.getPersonaInfo().getPicture());
+                    @Override
+                    protected void deliverResponse(Boolean result) {
+                        BusProvider.getInstance().post(new SoldierInformationUpdatedEvent(soldier));
+                        BusProvider.getInstance().post(new SoldierOverviewRefreshedEvent(result));
+                        stopSelf(startId);
                     }
-
-                    if (!statsDao.save(transaction)) {
-                        success = false;
-                    }
-
-                    transaction.setSuccessful(success);
-                    transaction.finish();
-                    return success;
                 }
-
-                @Override
-                protected void deliverResponse(Boolean result) {
-                    BusProvider.getInstance().post(new SoldierInformationUpdatedEvent(soldier));
-                    BusProvider.getInstance().post(new SoldierOverviewRefreshedEvent(result));
-                    stopSelf(startId);
-                }
-            }
-        );
+            );
+        }
         return Service.START_NOT_STICKY;
     }
 }

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/services/battlefeed/BattleFeedService.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/services/battlefeed/BattleFeedService.java
@@ -1,0 +1,48 @@
+package com.ninetwozero.bf4intel.services.battlefeed;
+
+import android.app.Service;
+import android.content.Intent;
+
+import com.ninetwozero.bf4intel.Bf4Intel;
+import com.ninetwozero.bf4intel.events.battlefeed.BattleFeedRefreshedEvent;
+import com.ninetwozero.bf4intel.factories.UrlFactory;
+import com.ninetwozero.bf4intel.json.battlefeed.BattleFeed;
+import com.ninetwozero.bf4intel.network.SimpleGetRequest;
+import com.ninetwozero.bf4intel.services.BaseApiService;
+import com.ninetwozero.bf4intel.utils.BusProvider;
+
+public class BattleFeedService extends BaseApiService {
+    public static final String INTENT_COUNT = "count";
+    public static final String INTENT_USERID = "userId";
+
+    @Override
+    public int onStartCommand(final Intent intent, final int flags, final int startId) {
+        super.onStartCommand(intent, flags, startId);
+
+        if (intentCount == 1) {
+            final int count = intent.getIntExtra(INTENT_COUNT, 0);
+            final String userId = intent.getStringExtra(INTENT_USERID);
+            final boolean fetchGlobalFeed = userId == null || userId.equals("");
+
+            Bf4Intel.getRequestQueue().add(
+                new SimpleGetRequest<BattleFeed>(
+                    fetchGlobalFeed ? UrlFactory.buildGlobalFeedURL(count) : UrlFactory.buildUserFeedURL(userId, count),
+                    this
+                ) {
+                    @Override
+                    protected BattleFeed doParse(String json) {
+                        final BattleFeed battleFeed = fromJson(json, BattleFeed.class);
+                        return battleFeed;
+                    }
+
+                    @Override
+                    protected void deliverResponse(BattleFeed items) {
+                        BusProvider.getInstance().post(new BattleFeedRefreshedEvent(items));
+                        stopSelf();
+                    }
+                }
+            );
+        }
+        return Service.START_NOT_STICKY;
+    }
+}

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/services/news/NewsArticleService.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/services/news/NewsArticleService.java
@@ -1,0 +1,50 @@
+package com.ninetwozero.bf4intel.services.news;
+
+import android.app.Service;
+import android.content.Intent;
+
+import com.google.gson.JsonElement;
+import com.ninetwozero.bf4intel.Bf4Intel;
+import com.ninetwozero.bf4intel.events.news.NewsArticleRefreshedEvent;
+import com.ninetwozero.bf4intel.factories.UrlFactory;
+import com.ninetwozero.bf4intel.json.news.NewsArticleRequest;
+import com.ninetwozero.bf4intel.network.BaseSimpleRequest;
+import com.ninetwozero.bf4intel.network.SimpleGetRequest;
+import com.ninetwozero.bf4intel.services.BaseApiService;
+import com.ninetwozero.bf4intel.utils.BusProvider;
+
+import java.net.URL;
+
+public class NewsArticleService extends BaseApiService {
+    public static final String INTENT_ARTICLE_ID = "articleId";
+
+    @Override
+    public int onStartCommand(final Intent intent, final int flags, final int startId) {
+        super.onStartCommand(intent, flags, startId);
+
+        if (intentCount == 1) {
+            final URL url = UrlFactory.buildNewsArticleURL(intent.getStringExtra(INTENT_ARTICLE_ID));
+            Bf4Intel.getRequestQueue().add(
+                new SimpleGetRequest<NewsArticleRequest>(
+                    url,
+                    BaseSimpleRequest.RequestType.FROM_NAVIGATION,
+                    this
+                ) {
+                    @Override
+                    protected NewsArticleRequest doParse(String json) {
+                        final JsonElement rootObject = extractFromJson(json, true).getAsJsonObject().get("context");
+                        final NewsArticleRequest articleRequest = gson.fromJson(rootObject, NewsArticleRequest.class);
+                        return articleRequest;
+                    }
+
+                    @Override
+                    protected void deliverResponse(NewsArticleRequest article) {
+                        BusProvider.getInstance().post(new NewsArticleRefreshedEvent(article));
+                        stopSelf();
+                    }
+                }
+            );
+        }
+        return Service.START_NOT_STICKY;
+    }
+}

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/services/news/NewsListingService.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/services/news/NewsListingService.java
@@ -1,0 +1,48 @@
+package com.ninetwozero.bf4intel.services.news;
+
+import android.app.Service;
+import android.content.Intent;
+
+import com.google.gson.JsonElement;
+import com.ninetwozero.bf4intel.Bf4Intel;
+import com.ninetwozero.bf4intel.events.news.NewsListingRefreshedEvent;
+import com.ninetwozero.bf4intel.factories.UrlFactory;
+import com.ninetwozero.bf4intel.json.news.NewsListRequest;
+import com.ninetwozero.bf4intel.network.BaseSimpleRequest;
+import com.ninetwozero.bf4intel.network.SimpleGetRequest;
+import com.ninetwozero.bf4intel.services.BaseApiService;
+import com.ninetwozero.bf4intel.utils.BusProvider;
+
+public class NewsListingService extends BaseApiService {
+    public static final String INTENT_PAGE_ID = "pageId";
+
+    @Override
+    public int onStartCommand(final Intent intent, final int flags, final int startId) {
+        super.onStartCommand(intent, flags, startId);
+
+        if (intentCount == 1) {
+            final int pageId = intent.getIntExtra(INTENT_PAGE_ID, 0);
+            Bf4Intel.getRequestQueue().add(
+                new SimpleGetRequest<NewsListRequest>(
+                    UrlFactory.buildNewsListingURL(pageId),
+                    BaseSimpleRequest.RequestType.FROM_NAVIGATION,
+                    this
+                ) {
+                    @Override
+                    protected NewsListRequest doParse(String json) {
+                        final JsonElement rootObject = extractFromJson(json, true).getAsJsonObject("context");
+                        final NewsListRequest container = gson.fromJson(rootObject, NewsListRequest.class);
+                        return container;
+                    }
+
+                    @Override
+                    protected void deliverResponse(NewsListRequest items) {
+                        BusProvider.getInstance().post(new NewsListingRefreshedEvent(items));
+                        stopSelf();
+                    }
+                }
+            );
+        }
+        return Service.START_NOT_STICKY;
+    }
+}

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/services/stats/reports/BattleReportService.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/services/stats/reports/BattleReportService.java
@@ -26,51 +26,54 @@ public class BattleReportService extends BaseApiService {
     @Override
     public int onStartCommand(final Intent intent, final int flags, final int startId) {
         super.onStartCommand(intent, flags, startId);
-        Bf4Intel.getRequestQueue().add(
-            new SimpleGetRequest<List<BaseListItem>>(
-                UrlFactory.buildBattleReportsURL(
-                    soldier.getString(Keys.Soldier.ID, ""),
-                    soldier.getInt(Keys.Soldier.PLATFORM, 0)
-                ),
-                this
-            ) {
-                @Override
-                protected List<BaseListItem> doParse(String json) {
-                    final List<BaseListItem> items = new ArrayList<BaseListItem>();
-                    final JsonObject baseObject = extractFromJson(json, false);
-                    if ((baseObject.get("statsTemplate").getAsString().equals("common.warsawerror"))) {
-                        return null;
+
+        if (intentCount == 1) {
+            Bf4Intel.getRequestQueue().add(
+                new SimpleGetRequest<List<BaseListItem>>(
+                    UrlFactory.buildBattleReportsURL(
+                        soldier.getString(Keys.Soldier.ID, ""),
+                        soldier.getInt(Keys.Soldier.PLATFORM, 0)
+                    ),
+                    this
+                ) {
+                    @Override
+                    protected List<BaseListItem> doParse(String json) {
+                        final List<BaseListItem> items = new ArrayList<BaseListItem>();
+                        final JsonObject baseObject = extractFromJson(json, false);
+                        if ((baseObject.get("statsTemplate").getAsString().equals("common.warsawerror"))) {
+                            return null;
+                        }
+
+                        final BattleReportStatistics statistics = gson.fromJson(baseObject, BattleReportStatistics.class);
+                        if (statistics.getFavoriteReports().size() > 0) {
+                            items.add(new SimpleListHeader(R.string.header_favorite_battlereport));
+                            items.addAll(buildBaseItemList(new ArrayList<GameReport>(statistics.getFavoriteReports()), statistics.getSoldierId()));
+                        }
+
+                        if (statistics.getStatsGameReports().size() > 0) {
+                            items.add(new SimpleListHeader(R.string.header_latest_battlereport));
+                            items.addAll(buildBaseItemList(new ArrayList<GameReport>(statistics.getStatsGameReports()), statistics.getSoldierId()));
+                        }
+
+                        return items;
                     }
 
-                    final BattleReportStatistics statistics = gson.fromJson(baseObject, BattleReportStatistics.class);
-                    if (statistics.getFavoriteReports().size() > 0) {
-                        items.add(new SimpleListHeader(R.string.header_favorite_battlereport));
-                        items.addAll(buildBaseItemList(new ArrayList<GameReport>(statistics.getFavoriteReports()), statistics.getSoldierId()));
+                    @Override
+                    protected void deliverResponse(List<BaseListItem> items) {
+                        BusProvider.getInstance().post(new BattleReportsRefreshedEvent(items));
+                        stopSelf();
                     }
 
-                    if (statistics.getStatsGameReports().size() > 0) {
-                        items.add(new SimpleListHeader(R.string.header_latest_battlereport));
-                        items.addAll(buildBaseItemList(new ArrayList<GameReport>(statistics.getStatsGameReports()), statistics.getSoldierId()));
+                    private List<BaseListItem> buildBaseItemList(final List<GameReport> reports, final int soldierId) {
+                        List<BaseListItem> itemsList = new ArrayList<BaseListItem>();
+                        for (GameReport report : reports) {
+                            itemsList.add(new BattleReportItem(report, soldierId, getApplicationContext()));
+                        }
+                        return itemsList;
                     }
-
-                    return items;
                 }
-
-                @Override
-                protected void deliverResponse(List<BaseListItem> items) {
-                    BusProvider.getInstance().post(new BattleReportsRefreshedEvent(items));
-                    stopSelf(startId);
-                }
-
-                private List<BaseListItem> buildBaseItemList(final List<GameReport> reports, final int soldierId) {
-                    List<BaseListItem> itemsList = new ArrayList<BaseListItem>();
-                    for (GameReport report : reports) {
-                        itemsList.add(new BattleReportItem(report, soldierId, getApplicationContext()));
-                    }
-                    return itemsList;
-                }
-            }
-        );
+            );
+        }
         return Service.START_NOT_STICKY;
     }
 }

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/login/LoginActivity.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/login/LoginActivity.java
@@ -87,9 +87,11 @@ public class LoginActivity extends BaseLoadingIntelActivity {
         }
     }
 
+
+    // TODO: Service?
     private void loadSoldiers(final Bundle bundle) {
         setLoadingState(true);
-        requestQueue.add(
+        Bf4Intel.getRequestQueue().add(
             new SimpleGetRequest<SoldierListingRequest>(
                 UrlFactory.buildSoldierListURL(bundle.getString(Keys.Profile.ID)),
                 this

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/news/NewsArticleFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/news/NewsArticleFragment.java
@@ -19,23 +19,22 @@ import android.widget.ShareActionProvider;
 
 import com.android.volley.Request;
 import com.android.volley.VolleyError;
-import com.google.gson.Gson;
 import com.google.gson.JsonElement;
-import com.google.gson.JsonParser;
+import com.ninetwozero.bf4intel.Bf4Intel;
 import com.ninetwozero.bf4intel.R;
 import com.ninetwozero.bf4intel.SessionStore;
 import com.ninetwozero.bf4intel.base.ui.BaseLoadingFragment;
 import com.ninetwozero.bf4intel.events.HooahToggleRequest;
+import com.ninetwozero.bf4intel.events.news.NewsArticleRefreshedEvent;
 import com.ninetwozero.bf4intel.factories.UrlFactory;
 import com.ninetwozero.bf4intel.json.news.HooahInformation;
 import com.ninetwozero.bf4intel.json.news.NewsArticle;
 import com.ninetwozero.bf4intel.json.news.NewsArticleComment;
 import com.ninetwozero.bf4intel.json.news.NewsArticleRequest;
-import com.ninetwozero.bf4intel.network.BaseSimpleRequest;
-import com.ninetwozero.bf4intel.network.SimpleGetRequest;
 import com.ninetwozero.bf4intel.network.SimplePostRequest;
 import com.ninetwozero.bf4intel.resources.Keys;
 import com.ninetwozero.bf4intel.resources.maps.WebsiteErrorMessageMap;
+import com.ninetwozero.bf4intel.services.news.NewsArticleService;
 import com.ninetwozero.bf4intel.ui.menu.RefreshEvent;
 import com.squareup.otto.Subscribe;
 
@@ -86,36 +85,37 @@ public class NewsArticleFragment extends BaseLoadingFragment implements ActionMo
     @Override
     protected void startLoadingData() {
         final Bundle arguments = getArguments();
-        if (arguments == null) {
-            throw new IllegalStateException("NULL bundle passed to " + TAG);
+        if (isReloading) {
+            return;
         }
+
+        showLoadingState(arguments.getBoolean(FLAG_SHOW_LOADING, true));
+        isReloading = true;
 
         articleId = arguments.getString(ID, "");
         articleUrl = UrlFactory.buildNewsArticleURL(articleId);
-        doRequest(ID_REQUEST_REFRESH_ARTICLE, arguments);
+
+        final Intent intent = new Intent(getActivity(), NewsArticleService.class);
+        intent.putExtra(NewsArticleService.INTENT_ARTICLE_ID, articleId);
+        getActivity().startService(intent);
     }
 
     private void doRequest(final int id, final Bundle bundle) {
         switch (id) {
-            case ID_REQUEST_REFRESH_ARTICLE:
-                showLoadingState(bundle.getBoolean(FLAG_SHOW_LOADING, true));
-                requestQueue.add(fetchRequestForArticleRefresh(bundle));
-                break;
-
             case ID_REQUEST_HOOAH:
-                requestQueue.add(fetchRequestForHooah(bundle));
+                Bf4Intel.getRequestQueue().add(fetchRequestForHooah(bundle));
                 break;
 
             case ID_REQUEST_POST_COMMENT:
-                requestQueue.add(fetchRequestForPostComment(bundle));
+                Bf4Intel.getRequestQueue().add(fetchRequestForPostComment(bundle));
                 break;
 
             case ID_REQUEST_COMMENT_UPVOTE:
-                requestQueue.add(fetchRequestForCommentUpvote(bundle));
+                Bf4Intel.getRequestQueue().add(fetchRequestForCommentUpvote(bundle));
                 break;
 
             case ID_REQUEST_COMMENT_DOWNVOTE:
-                requestQueue.add(fetchRequestForCommentDownvote(bundle));
+                Bf4Intel.getRequestQueue().add(fetchRequestForCommentDownvote(bundle));
                 break;
 
             default:
@@ -123,27 +123,11 @@ public class NewsArticleFragment extends BaseLoadingFragment implements ActionMo
         }
     }
 
-    private Request<NewsArticleRequest> fetchRequestForArticleRefresh(Bundle bundle) {
-        return new SimpleGetRequest<NewsArticleRequest>(
-            articleUrl,
-            BaseSimpleRequest.RequestType.FROM_NAVIGATION,
-            this
-        ) {
-            @Override
-            protected NewsArticleRequest doParse(String json) {
-                final Gson gson = new Gson();
-                final JsonParser parser = new JsonParser();
-                final JsonElement rootObject = parser.parse(json).getAsJsonObject().get("context");
-                final NewsArticleRequest articleRequest = gson.fromJson(rootObject, NewsArticleRequest.class);
-                return articleRequest;
-            }
-
-            @Override
-            protected void deliverResponse(NewsArticleRequest response) {
-                displayArticle(response);
-                showLoadingState(false);
-            }
-        };
+    @Subscribe
+    public void onArticleRefreshed(NewsArticleRefreshedEvent response) {
+        displayArticle(response.getRequest());
+        showLoadingState(false);
+        isReloading = false;
     }
 
     private Request<HooahInformation> fetchRequestForHooah(Bundle bundle) {

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/news/NewsListingFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/news/NewsListingFragment.java
@@ -13,10 +13,13 @@ import com.android.volley.VolleyError;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import com.ninetwozero.bf4intel.Bf4Intel;
 import com.ninetwozero.bf4intel.R;
 import com.ninetwozero.bf4intel.SessionStore;
 import com.ninetwozero.bf4intel.base.ui.BaseLoadingListFragment;
 import com.ninetwozero.bf4intel.events.HooahToggleRequest;
+import com.ninetwozero.bf4intel.events.awards.AwardsRefreshedEvent;
+import com.ninetwozero.bf4intel.events.news.NewsListingRefreshedEvent;
 import com.ninetwozero.bf4intel.factories.FragmentFactory;
 import com.ninetwozero.bf4intel.factories.UrlFactory;
 import com.ninetwozero.bf4intel.json.news.NewsArticle;
@@ -26,6 +29,8 @@ import com.ninetwozero.bf4intel.network.SimpleGetRequest;
 import com.ninetwozero.bf4intel.network.SimplePostRequest;
 import com.ninetwozero.bf4intel.resources.Keys;
 import com.ninetwozero.bf4intel.resources.maps.WebsiteErrorMessageMap;
+import com.ninetwozero.bf4intel.services.AwardService;
+import com.ninetwozero.bf4intel.services.news.NewsListingService;
 import com.ninetwozero.bf4intel.ui.activities.SingleFragmentActivity;
 import com.ninetwozero.bf4intel.ui.menu.RefreshEvent;
 import com.squareup.otto.Subscribe;
@@ -34,9 +39,7 @@ import java.util.List;
 
 public class NewsListingFragment extends BaseLoadingListFragment {
     public static final String ID = "articleId";
-    
-    private static final int ID_REQUEST_REFRESH_LIST = 4000;
-    private static final int ID_REQUEST_HOOAH = 4100;
+
     private static final int pageId = 1;
 
     public NewsListingFragment() {
@@ -67,57 +70,31 @@ public class NewsListingFragment extends BaseLoadingListFragment {
         final Bundle data = new Bundle();
         data.putString(NewsArticleFragment.ID, String.valueOf(id));
 
-        startActivity(
-            new Intent(getActivity(), SingleFragmentActivity.class).putExtra(
-                SingleFragmentActivity.INTENT_FRAGMENT_TYPE, FragmentFactory.Type.NEWS_ITEM.ordinal()
-            ).putExtra(
-                SingleFragmentActivity.INTENT_FRAGMENT_DATA, data
-            )
-        );
+        final Intent intent = new Intent(getActivity(), SingleFragmentActivity.class);
+        intent.putExtra(SingleFragmentActivity.INTENT_FRAGMENT_TYPE, FragmentFactory.Type.NEWS_ITEM.ordinal());
+        intent.putExtra(SingleFragmentActivity.INTENT_FRAGMENT_DATA, data);
+        startActivity(intent);
     }
 
     @Override
     protected void startLoadingData() {
-        doRequest(ID_REQUEST_REFRESH_LIST, getArguments());
-    }
-
-    private void doRequest(int requestId, Bundle bundle) {
-        switch(requestId) {
-            case ID_REQUEST_REFRESH_LIST:
-                showLoadingState(true);
-                requestQueue.add(fetchRequestForRefresh(bundle));
-                break;
-
-            case ID_REQUEST_HOOAH:
-                requestQueue.add(fetchRequestForHooah(bundle));
-                break;
-
-            default:
-                Log.w(getClass().getSimpleName(), "No request matching " + requestId);
+        if (isReloading) {
+            return;
         }
+
+        showLoadingState(true);
+        isReloading = true;
+
+        final Intent intent = new Intent(getActivity(), NewsListingService.class);
+        intent.putExtra(NewsListingService.INTENT_PAGE_ID, pageId);
+        getActivity().startService(intent);
     }
 
-    private Request<NewsListRequest> fetchRequestForRefresh(Bundle bundle) {
-        return new SimpleGetRequest<NewsListRequest>(
-            UrlFactory.buildNewsListingURL(pageId),
-            BaseSimpleRequest.RequestType.FROM_NAVIGATION,
-            this
-        ) {
-            @Override
-            protected NewsListRequest doParse(String json) {
-                final Gson gson = new Gson();
-                final JsonParser parser = new JsonParser();
-                final JsonElement rootObject = parser.parse(json).getAsJsonObject().get("context");
-                final NewsListRequest container = gson.fromJson(rootObject, NewsListRequest.class);
-                return container;
-            }
-
-            @Override
-            protected void deliverResponse(NewsListRequest response) {
-                sendItemsToListView(response.getArticles());
-                showLoadingState(false);
-            }
-        };
+    @Subscribe
+    public void onNewsRefreshed(NewsListingRefreshedEvent response) {
+        sendItemsToListView(response.getRequest().getArticles());
+        showLoadingState(false);
+        isReloading = false;
     }
 
     private Request<Object> fetchRequestForHooah(Bundle bundle) {
@@ -155,7 +132,7 @@ public class NewsListingFragment extends BaseLoadingListFragment {
         data.putString(Keys.CHECKSUM, SessionStore.getChecksum());
         data.putString(ID, request.getId());
 
-        doRequest(ID_REQUEST_HOOAH, data);
+        Bf4Intel.getRequestQueue().add(fetchRequestForHooah(data));
     }
 
     private void initialize() {

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/search/ProfileSearchFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/search/ProfileSearchFragment.java
@@ -15,6 +15,7 @@ import android.widget.SearchView;
 import android.widget.TextView;
 
 import com.android.volley.Request;
+import com.ninetwozero.bf4intel.Bf4Intel;
 import com.ninetwozero.bf4intel.R;
 import com.ninetwozero.bf4intel.base.ui.BaseLoadingListFragment;
 import com.ninetwozero.bf4intel.factories.FragmentFactory;
@@ -99,8 +100,11 @@ public class ProfileSearchFragment extends BaseLoadingListFragment {
 
     @Override
     protected void startLoadingData() {
-        final Bundle postData = new Bundle();
+        if (isReloading) {
+            return;
+        }
 
+        final Bundle postData = new Bundle();
         if (queryString == null || queryString.length() < 3) {
             showToast(R.string.msg_search_error_length);
             return;
@@ -110,7 +114,10 @@ public class ProfileSearchFragment extends BaseLoadingListFragment {
         postData.putString(Keys.CHECKSUM, "0xCAFEBABE");
 
         showLoadingState(true);
-        requestQueue.add(fetchRequestForSearch(postData));
+        isReloading = true;
+
+        // TODO: Service in the future?
+        Bf4Intel.getRequestQueue().add(fetchRequestForSearch(postData));
     }
 
     @Override
@@ -185,6 +192,7 @@ public class ProfileSearchFragment extends BaseLoadingListFragment {
             protected void deliverResponse(List<ProfileSearchResult> response) {
                 sendDataToListView(response);
                 showLoadingState(false);
+                isReloading = false;
             }
         };
     }

--- a/BF4Intel/src/main/res/values/strings.xml
+++ b/BF4Intel/src/main/res/values/strings.xml
@@ -25,6 +25,8 @@
   <string name="label_service_unlocks_kits">Kit Unlocks Service</string>
   <string name="label_service_assignments">Assignment Service</string>
   <string name="label_service_awards">Award Service</string>
+  <string name="label_service_battlefeed">Battle Feed Service</string>
+  <string name="label_service_news">News Service</string>
 
   <!--Navigation drawer-->
   <string name="navigationdrawer_selected_soldier">Selected soldier</string>


### PR DESCRIPTION
OK, this is an attempt to fix the database related crashes. As far as my testing goes, it requires a lot more rotations to crash LOL. Which, is good.

I bumped Sprinkles up to 1.3.0-SNAPSHOT as well, and my take on the issue is that it's not related to Sprinkles - it's more of a "hey, y'all running the networking in the service too often" type of thing. As a way to sort that issue, I've added the means to only let one intent through at a given time, to keep it from spamming requests and eating threads.
