### PR TITLE
Fix progressbar issue in AssignmentsAdapter

### DIFF
--- a/BF4Intel/src/main/assets/changelog.htm
+++ b/BF4Intel/src/main/assets/changelog.htm
@@ -44,6 +44,7 @@
 <h1 class="group-header">Version 0.9.6</h1>
 <article>
     <ul>
+        <li>Fixed issue with Assignments progress bar that was showing wrong value</li>
         <li>Optimized image loading in the app (should go way smoother)</li>
         <li>Assignment data is now stored locally</li>
         <li>Award data is now stored locally</li>

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/assignments/AssignmentsAdapter.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/assignments/AssignmentsAdapter.java
@@ -42,9 +42,8 @@ public class AssignmentsAdapter extends BaseIntelAdapter<Assignment> {
             setVisibility(view, R.id.expansion_icon, View.INVISIBLE);
         }
 
-        if (assignment.isTracking()) {
-            populateViewForTracking(view, assignment);
-        } else {
+        populateViewForTracking(view, assignment);
+        if (!assignment.isTracking()) {
             setVisibility(view, R.id.img_assignment_prerequisite, View.VISIBLE);
         }
 


### PR DESCRIPTION
OK, it looks as if we were incorrectly putting the "update progressbar" code within the selection. Previously, when it didn't get to the progressbar-updating code, it would just show the state of the progressbar already available in the recycled view, which made it appear a bit... random.

@peter-budo 
