### PR TITLE
Fix issues when selecting a new profile

### DIFF
--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/base/ui/BaseTabFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/base/ui/BaseTabFragment.java
@@ -32,6 +32,14 @@ public abstract class BaseTabFragment extends BaseFragment {
         return view;
     }
 
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+
+        viewPagerAdapter = null;
+        viewPager = null;
+    }
+
     private void initialize(final View view) {
         setupViewPagerAdapter();
         setupViewPager(view);
@@ -56,7 +64,7 @@ public abstract class BaseTabFragment extends BaseFragment {
 
     private void setupViewPagerAdapter() {
         viewPagerAdapter = new ViewPagerAdapter(
-            getFragmentManager(),
+            getChildFragmentManager(),
             getTitleResources(),
             generateFragmentList(getPreparedArguments())
         );

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/assignments/AssignmentGridFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/assignments/AssignmentGridFragment.java
@@ -61,7 +61,9 @@ public class AssignmentGridFragment
                 @Override
                 public boolean handleResult(AssignmentsDAO assignmentsDAO) {
                     final View view = getView();
-                    if (view == null || assignmentsDAO == null) {
+                    if (view == null) {
+                        return true;
+                    } else if (assignmentsDAO == null) {
                         startLoadingData();
                         return true;
                     }

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/awards/AwardGridFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/awards/AwardGridFragment.java
@@ -62,7 +62,9 @@ public class AwardGridFragment
                 @Override
                 public boolean handleResult(AwardsDAO awardsDao) {
                     final View view = getView();
-                    if (view == null || awardsDao == null) {
+                    if (view == null) {
+                        return true;
+                    } else if (awardsDao == null) {
                         startLoadingData();
                         return true;
                     }

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/fragments/NavigationDrawerFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/fragments/NavigationDrawerFragment.java
@@ -15,6 +15,8 @@ import com.ninetwozero.bf4intel.SessionStore;
 import com.ninetwozero.bf4intel.base.ui.BaseFragment;
 import com.ninetwozero.bf4intel.base.ui.BaseListFragment;
 import com.ninetwozero.bf4intel.dao.login.SummarizedSoldierStatsDAO;
+import com.ninetwozero.bf4intel.events.ActiveSoldierChangedEvent;
+import com.ninetwozero.bf4intel.events.SoldierInformationUpdatedEvent;
 import com.ninetwozero.bf4intel.events.TrackingNewProfileEvent;
 import com.ninetwozero.bf4intel.factories.BundleFactory;
 import com.ninetwozero.bf4intel.factories.FragmentFactory;
@@ -24,10 +26,8 @@ import com.ninetwozero.bf4intel.menu.ListRowType;
 import com.ninetwozero.bf4intel.menu.SimpleListRow;
 import com.ninetwozero.bf4intel.resources.Keys;
 import com.ninetwozero.bf4intel.ui.adapters.NavigationDrawerListAdapter;
-import com.ninetwozero.bf4intel.events.ActiveSoldierChangedEvent;
 import com.ninetwozero.bf4intel.utils.BusProvider;
 import com.ninetwozero.bf4intel.utils.ExternalAppLauncher;
-import com.ninetwozero.bf4intel.events.SoldierInformationUpdatedEvent;
 import com.squareup.otto.Subscribe;
 
 import java.util.ArrayList;
@@ -369,7 +369,11 @@ public class NavigationDrawerFragment extends BaseListFragment {
             try {
                 final FragmentTransaction transaction = fragmentManager.beginTransaction();
                 final String tag = item.getFragmentType().toString();
-                transaction.replace(R.id.activity_root, FragmentFactory.get(item.getFragmentType(), item.getData()), tag);
+                transaction.replace(
+                    R.id.activity_root,
+                    FragmentFactory.get(item.getFragmentType(), item.getData()),
+                    tag
+                );
                 transaction.commit();
             } catch (TypeNotPresentException ex) {
                 showToast(ex.getMessage());

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/fragments/SoldierOverviewFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/fragments/SoldierOverviewFragment.java
@@ -78,7 +78,9 @@ public class SoldierOverviewFragment extends BaseLoadingFragment {
                 @Override
                 public boolean handleResult(SoldierOverviewDAO soldierOverviewDAO) {
                     final View view = getView();
-                    if (view == null || soldierOverviewDAO == null) {
+                    if (view == null) {
+                        return true;
+                    } else if (soldierOverviewDAO == null) {
                         startLoadingData();
                         return true;
                     }

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/login/LoginActivity.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/login/LoginActivity.java
@@ -242,6 +242,8 @@ public class LoginActivity extends BaseLoadingIntelActivity {
         if ("".equals(searchTerm) || searchTerm.length() < 3) {
             searchField.setError(getString(R.string.msg_search_error_length));
             return;
+        } else {
+            searchField.setError(null);
         }
 
         startActivityForResult(

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/login/LoginActivity.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/login/LoginActivity.java
@@ -44,6 +44,7 @@ public class LoginActivity extends BaseLoadingIntelActivity {
 
     private static final String RESET_PASSWORD_LINK = "https://signin.ea.com/p/web/resetPassword";
     private static final int GAME_ID_BF4 = 2048;
+    private static final int GAME_ID_MOHW = 4096;
 
     private Bundle profileBundle;
     private View loginStatusView;
@@ -88,7 +89,7 @@ public class LoginActivity extends BaseLoadingIntelActivity {
     }
 
 
-    // TODO: Service?
+    // TODO: Refactor functionality to a service?
     private void loadSoldiers(final Bundle bundle) {
         setLoadingState(true);
         Bf4Intel.getRequestQueue().add(
@@ -108,7 +109,7 @@ public class LoginActivity extends BaseLoadingIntelActivity {
 
                     for (int i = 0; i < soldierCount; i++) {
                         final SummarizedSoldierStats stats = request.getSoldiers().get(i);
-                        if (stats.getGameId() == GAME_ID_BF4) {
+                        if (stats.getGameId() >= GAME_ID_BF4 && stats.getGameId() < GAME_ID_MOHW) {
                             if (bf4SoldierCount == 0) {
                                 new SqlStatement(
                                     "DELETE FROM " +

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/search/ProfileSearchFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/search/ProfileSearchFragment.java
@@ -87,6 +87,8 @@ public class ProfileSearchFragment extends BaseLoadingListFragment {
                 }
             );
             searchView.setIconifiedByDefault(true);
+            searchView.setIconified(false);
+            searchView.clearFocus();
             searchView.setQuery(queryString, true);
             searchItem.setVisible(true);
         }

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/search/ProfileSearchFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/search/ProfileSearchFragment.java
@@ -37,6 +37,7 @@ public class ProfileSearchFragment extends BaseLoadingListFragment {
     public static final String INTENT_SEARCH_RESULT = "profile_search_result";
 
     private static final int GAME_ID_BF4 = 2048;
+    private static final int GAME_ID_MOHW = 4096;
 
     private String queryString;
 
@@ -93,9 +94,10 @@ public class ProfileSearchFragment extends BaseLoadingListFragment {
 
     /*
         Due to Battlelog doing the search by the soldier name (and not the username), we need to
-        get the users that are playing BF4 (gameId >= 2048)
+        get the users that are playing BF4 but not MOHW (gameId >= 2048 && gameId < 4096)
 
         Info: http://battlelog.battlefield.com/bf4/user/haruhi00/
+        Info: http://battlelog.battlefield.com/bf4/user/cursef (MOHW)
     */
 
     @Override
@@ -202,7 +204,8 @@ public class ProfileSearchFragment extends BaseLoadingListFragment {
         for (ProfileSearchResult result : results) {
             Map<Integer, Integer> games = result.getGames();
             for (int platformId : games.keySet()) {
-                if (games.get(platformId) >= GAME_ID_BF4) {
+                final int gameForPlatform = games.get(platformId);
+                if (gameForPlatform >= GAME_ID_BF4 && gameForPlatform < GAME_ID_MOHW) {
                     validAccounts.add(
                         new ProfileSearchResult(
                             result.getPersonaId(),

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/stats/details/DetailedStatsFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/stats/details/DetailedStatsFragment.java
@@ -60,7 +60,9 @@ public class DetailedStatsFragment extends BaseLoadingFragment {
                 @Override
                 public boolean handleResult(DetailedStatsDAO detailedStatsDAO) {
                     final View view = getView();
-                    if (view == null || detailedStatsDAO == null) {
+                    if (view == null) {
+                        return true;
+                    } else if (detailedStatsDAO == null) {
                         startLoadingData();
                         return true;
                     }

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/stats/vehicles/VehicleStatsFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/stats/vehicles/VehicleStatsFragment.java
@@ -58,7 +58,9 @@ public class VehicleStatsFragment extends BaseLoadingListFragment {
                 @Override
                 public boolean handleResult(VehicleStatsDAO vehiclestatsDAO) {
                     final View view = getView();
-                    if (view == null || vehiclestatsDAO == null) {
+                    if (view == null) {
+                        return true;
+                    } else if (vehiclestatsDAO == null) {
                         startLoadingData();
                         return true;
                     }

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/stats/weapons/WeaponStatsFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/stats/weapons/WeaponStatsFragment.java
@@ -58,7 +58,9 @@ public class WeaponStatsFragment extends BaseLoadingListFragment {
                 @Override
                 public boolean handleResult(WeaponStatsDAO weaponstatsDAO) {
                     final View view = getView();
-                    if (view == null || weaponstatsDAO == null) {
+                    if (view == null) {
+                        return true;
+                    } else if (weaponstatsDAO == null) {
                         startLoadingData();
                         return true;
                     }

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/unlocks/kits/KitUnlockFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/unlocks/kits/KitUnlockFragment.java
@@ -45,7 +45,9 @@ public class KitUnlockFragment extends BaseUnlockFragment {
                 @Override
                 public boolean handleResult(KitUnlockDAO kitUnlockDAO) {
                     final View view = getView();
-                    if (view == null || kitUnlockDAO == null) {
+                    if (view == null) {
+                        return true;
+                    } else if (kitUnlockDAO == null) {
                         startLoadingData();
                         return true;
                     }

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/unlocks/vehicles/VehicleUnlockFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/unlocks/vehicles/VehicleUnlockFragment.java
@@ -45,7 +45,9 @@ public class VehicleUnlockFragment extends BaseUnlockFragment {
                 @Override
                 public boolean handleResult(VehicleUnlockDAO vehicleUnlockDAO) {
                     final View view = getView();
-                    if (view == null || vehicleUnlockDAO == null) {
+                    if (view == null) {
+                        return true;
+                    } else if (vehicleUnlockDAO == null) {
                         startLoadingData();
                         return true;
                     }

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/unlocks/weapons/WeaponUnlockFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/unlocks/weapons/WeaponUnlockFragment.java
@@ -45,7 +45,9 @@ public class WeaponUnlockFragment extends BaseUnlockFragment {
                 @Override
                 public boolean handleResult(WeaponUnlockDAO weaponUnlockDAO) {
                     final View view = getView();
-                    if (view == null || weaponUnlockDAO == null) {
+                    if (view == null) {
+                        return true;
+                    } else if (weaponUnlockDAO == null) {
                         startLoadingData();
                         return true;
                     }


### PR DESCRIPTION
@peter-budo:

OK, it seems as if `getFragmentManager()` + nested fragments is... well, not the way to do it. `getChildFragmentManager()` makes sure we recycle fragments. :-)

However, the reload bug still persists when viewing the stats of a new profile for the FIRST time. Subsequent searches for the profile will work fine though, but it's like something's a bit fishy with that first load. Hm.

Investigation continuing. 
