### PR TITLE
Minor changes before release

### DIFF
--- a/BF4Intel/src/main/assets/licenses.htm
+++ b/BF4Intel/src/main/assets/licenses.htm
@@ -115,14 +115,14 @@
     </article>
     <article>
         <h1>Sprinkles</h1>
-        <em>&copy; 2014 Emil Sj&ouml;lander</em>
+        <em>&copy; 2013 Emil Sj&ouml;lander</em>
         <p>Project homepage: <a href="https://github.com/emilsjolander/sprinkles">https://github.com/emilsjolander/sprinkles</a></p>
         <span>License: <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</a></span>
     </article>
     <article>
-        <h1>StickyGridHeaders</h1>
-        <em>&copy; 2013 Tonic Artos</em>
-        <p>Project homepage: <a href="https://github.com/TonicArtos/StickyGridHeaders">https://github.com/TonicArtos/StickyGridHeaders</a></p>
+        <h1>StickyListHeaders</h1>
+        <em>&copy; 2012 Emil Sj&ouml;lander</em>
+        <p>Project homepage: <a href="https://github.com/emilsjolander/StickyListHeaders">https://github.com/emilsjolander/StickyListHeaders</a></p>
         <span>License: <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</a></span>
     </article>
 </body>

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/news/NewsArticleFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/news/NewsArticleFragment.java
@@ -69,6 +69,14 @@ public class NewsArticleFragment extends BaseLoadingFragment implements ActionMo
     }
 
     @Override
+    public void onCreate(Bundle icicle) {
+        articleId = getArguments().getString(ID, "");
+        articleUrl = UrlFactory.buildNewsArticleURL(articleId);
+
+        super.onCreate(icicle);
+    }
+
+    @Override
     public View onCreateView(final LayoutInflater inflater, final ViewGroup parent, final Bundle state) {
         super.onCreateView(inflater, parent, state);
 
@@ -97,9 +105,6 @@ public class NewsArticleFragment extends BaseLoadingFragment implements ActionMo
 
         showLoadingState(arguments.getBoolean(FLAG_SHOW_LOADING, true));
         isReloading = true;
-
-        articleId = arguments.getString(ID, "");
-        articleUrl = UrlFactory.buildNewsArticleURL(articleId);
 
         final Intent intent = new Intent(getActivity(), NewsArticleService.class);
         intent.putExtra(NewsArticleService.INTENT_ARTICLE_ID, articleId);
@@ -300,7 +305,6 @@ public class NewsArticleFragment extends BaseLoadingFragment implements ActionMo
 
     private void initialize(final View view) {
         setupErrorMessage(view);
-        setHasOptionsMenu(true);
         setupActionBar();
         setupListView(view);
         setupForm(view);

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/search/ProfileSearchFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/search/ProfileSearchFragment.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Map;
 
 public class ProfileSearchFragment extends BaseLoadingListFragment {
-    public static final String INTENT_SEARCH_RESULT = "profile_search_result";
+    public static final String INTENT_QUERY_STRING = "query_string";
 
     private static final int GAME_ID_BF4 = 2048;
     private static final int GAME_ID_MOHW = 4096;
@@ -47,6 +47,11 @@ public class ProfileSearchFragment extends BaseLoadingListFragment {
         return fragment;
     }
 
+    @Override
+    public void onCreate(Bundle icicle) {
+        queryString = getArguments().getString(INTENT_QUERY_STRING, "");
+        super.onCreate(icicle);
+    }
 
     @Override
     public View onCreateView(final LayoutInflater inflater, final ViewGroup parent, final Bundle state) {
@@ -166,12 +171,7 @@ public class ProfileSearchFragment extends BaseLoadingListFragment {
 
     private void initialize(final View view) {
         setupErrorMessage(view);
-        setupDataFromBundle(getArguments());
         setupListView(view);
-    }
-
-    private void setupDataFromBundle(final Bundle arguments) {
-        queryString = arguments.getString(INTENT_SEARCH_RESULT, "");
     }
 
     private void setupListView(final View view) {

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/search/SearchActivity.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/search/SearchActivity.java
@@ -84,7 +84,7 @@ public class SearchActivity extends BaseIntelActivity {
             finish();
         }
 
-        bundle.putString(ProfileSearchFragment.INTENT_SEARCH_RESULT, query);
+        bundle.putString(ProfileSearchFragment.INTENT_QUERY_STRING, query);
         return bundle;
     }
 

--- a/BF4Intel/src/main/res/layout-sw720dp/fragment_soldier_overview.xml
+++ b/BF4Intel/src/main/res/layout-sw720dp/fragment_soldier_overview.xml
@@ -378,4 +378,5 @@
   </ScrollView>
 
   <include layout="@layout/loading_progress" />
+  <include layout="@layout/inlined_error_message" />
 </RelativeLayout>

--- a/BF4Intel/src/main/res/layout/activity_login.xml
+++ b/BF4Intel/src/main/res/layout/activity_login.xml
@@ -125,8 +125,5 @@
       />
   </LinearLayout>
 
-  <include
-    android:id="@+id/inline_error_message"
-    layout="@layout/inlined_error_message"
-    />
+  <include layout="@layout/inlined_error_message" />
 </RelativeLayout>

--- a/BF4Intel/src/main/res/layout/fragment_card_grid.xml
+++ b/BF4Intel/src/main/res/layout/fragment_card_grid.xml
@@ -12,9 +12,5 @@
     />
 
   <include layout="@layout/loading_progress"/>
-
-  <include
-    android:id="@+id/inline_error_message"
-    layout="@layout/inlined_error_message"
-    />
+  <include layout="@layout/inlined_error_message" />
 </RelativeLayout>

--- a/BF4Intel/src/main/res/layout/fragment_list_stats.xml
+++ b/BF4Intel/src/main/res/layout/fragment_list_stats.xml
@@ -19,10 +19,5 @@
     />
 
   <include layout="@layout/loading_progress" />
-
-  <include
-    android:id="@+id/inline_error_message"
-    layout="@layout/inlined_error_message"
-    />
-
+  <include layout="@layout/inlined_error_message" />
 </RelativeLayout>

--- a/BF4Intel/src/main/res/layout/fragment_news_article.xml
+++ b/BF4Intel/src/main/res/layout/fragment_news_article.xml
@@ -53,25 +53,6 @@
       android:layout_height="wrap_content"
       />
   </ScrollView>
-  <LinearLayout
-    android:id="@+id/wrap_loading_progress"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:visibility="gone"
-    android:gravity="center"
-    android:background="@color/white"
-    >
-      <ProgressBar
-        style="?android:progressBarStyleLarge"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:indeterminate="true"
-        />
-    </LinearLayout>
-
-  <include
-    android:id="@+id/inline_error_message"
-    layout="@layout/inlined_error_message"
-    />
+  <include layout="@layout/loading_progress"/>
+  <include layout="@layout/inlined_error_message"/>
 </RelativeLayout>

--- a/BF4Intel/src/main/res/layout/fragment_news_listing.xml
+++ b/BF4Intel/src/main/res/layout/fragment_news_listing.xml
@@ -20,9 +20,5 @@
     />
 
   <include layout="@layout/loading_progress" />
-
-  <include
-    android:id="@+id/inline_error_message"
-    layout="@layout/inlined_error_message"
-    />
+  <include layout="@layout/inlined_error_message" />
 </RelativeLayout>

--- a/BF4Intel/src/main/res/layout/fragment_profile_search.xml
+++ b/BF4Intel/src/main/res/layout/fragment_profile_search.xml
@@ -16,9 +16,5 @@
     />
 
   <include layout="@layout/loading_progress"/>
-
-  <include
-    android:id="@+id/inline_error_message"
-    layout="@layout/inlined_error_message"
-    />
+  <include layout="@layout/inlined_error_message"/>
 </RelativeLayout>

--- a/BF4Intel/src/main/res/layout/fragment_soldier_overview.xml
+++ b/BF4Intel/src/main/res/layout/fragment_soldier_overview.xml
@@ -286,9 +286,5 @@
   </ScrollView>
 
   <include layout="@layout/loading_progress" />
-
-  <include
-    android:id="@+id/inline_error_message"
-    layout="@layout/inlined_error_message"
-    />
+  <include layout="@layout/inlined_error_message" />
 </RelativeLayout>

--- a/BF4Intel/src/main/res/layout/fragment_unlocks.xml
+++ b/BF4Intel/src/main/res/layout/fragment_unlocks.xml
@@ -15,9 +15,5 @@
     />
 
   <include layout="@layout/loading_progress" />
-
-  <include
-    android:id="@+id/inline_error_message"
-    layout="@layout/inlined_error_message"
-    />
+  <include layout="@layout/inlined_error_message"/>
 </RelativeLayout>

--- a/BF4Intel/src/main/res/layout/generic_list.xml
+++ b/BF4Intel/src/main/res/layout/generic_list.xml
@@ -24,8 +24,5 @@
 
   <include layout="@layout/loading_progress" />
 
-  <include
-    android:id="@+id/inline_error_message"
-    layout="@layout/inlined_error_message"
-    />
+  <include layout="@layout/inlined_error_message"/>
 </RelativeLayout>

--- a/BF4Intel/src/main/res/layout/generic_sticky_list.xml
+++ b/BF4Intel/src/main/res/layout/generic_sticky_list.xml
@@ -25,9 +25,5 @@
     />
 
   <include layout="@layout/loading_progress" />
-
-  <include
-    android:id="@+id/inline_error_message"
-    layout="@layout/inlined_error_message"
-    />
+  <include layout="@layout/inlined_error_message"/>
 </RelativeLayout>

--- a/BF4Intel/src/main/res/layout/inlined_error_message.xml
+++ b/BF4Intel/src/main/res/layout/inlined_error_message.xml
@@ -2,6 +2,7 @@
 
 <TextView
   xmlns:android="http://schemas.android.com/apk/res/android"
+  android:id="@+id/inline_error_message"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
   android:gravity="center"

--- a/BF4Intel/src/main/res/layout/loading_progress.xml
+++ b/BF4Intel/src/main/res/layout/loading_progress.xml
@@ -12,6 +12,7 @@
   >
 
   <ProgressBar
+    style="?android:progressBarStyleLarge"
     android:id="@+id/progress_bar"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"


### PR DESCRIPTION
@peter-budo:

Interesting change in the support library: `onCreateOptionsMenu` seems to be called _directly_ after `setHasOptionsMenu(true)` has been called, which broke both the news and the search. Weird!

What's even more weird is that I haven't seen this behaviour on the Nexus 5 either. :hear_no_evil: 
