### PR TITLE
Fix NavigationDrawer state on orientation change

### DIFF
--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/activities/MainActivity.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/activities/MainActivity.java
@@ -118,7 +118,12 @@ public class MainActivity extends BaseIntelActivity implements NavigationDrawerF
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putBoolean(STATE_DRAWER_OPENED, isDrawerOpen() || shouldShowDualPane);
+
+        if (shouldShowDualPane) {
+            outState.putBoolean(STATE_DRAWER_OPENED, false);
+        } else {
+            outState.putBoolean(STATE_DRAWER_OPENED, isDrawerOpen());
+        }
     }
 
 


### PR DESCRIPTION
@peter-budo:

Small correction to how it should work - if you're running the app on a tablet, and you go from landscape --> portrait, it shouldn't show the NavigationDrawer "just because". :ru: 
