### PR TITLE
Update "BF4 soldier filter" for PC edge cases

### DIFF
--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/login/LoginActivity.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/login/LoginActivity.java
@@ -33,6 +33,7 @@ import com.ninetwozero.bf4intel.ui.about.AppInfoActivity;
 import com.ninetwozero.bf4intel.ui.activities.MainActivity;
 import com.ninetwozero.bf4intel.ui.search.SearchActivity;
 import com.ninetwozero.bf4intel.utils.BusProvider;
+import com.ninetwozero.bf4intel.utils.PersonaUtils;
 
 import java.util.List;
 import se.emilsjolander.sprinkles.SqlStatement;
@@ -42,8 +43,6 @@ public class LoginActivity extends BaseLoadingIntelActivity {
     public static final int REQUEST_PROFILE = 0;
 
     private static final String RESET_PASSWORD_LINK = "https://signin.ea.com/p/web/resetPassword";
-    private static final int GAME_ID_BF4 = 2048;
-    private static final int GAME_ID_MOHW = 4096;
 
     private Bundle profileBundle;
     private View loginStatusView;
@@ -108,7 +107,7 @@ public class LoginActivity extends BaseLoadingIntelActivity {
 
                     for (int i = 0; i < soldierCount; i++) {
                         final SummarizedSoldierStats stats = request.getSoldiers().get(i);
-                        if (stats.getGameId() >= GAME_ID_BF4 && stats.getGameId() < GAME_ID_MOHW) {
+                        if (PersonaUtils.isBf4Soldier(stats.getGameId())) {
                             if (bf4SoldierCount == 0) {
                                 new SqlStatement(
                                     "DELETE FROM " +

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/search/ProfileSearchFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/search/ProfileSearchFragment.java
@@ -28,6 +28,7 @@ import com.ninetwozero.bf4intel.resources.Keys;
 import com.ninetwozero.bf4intel.resources.maps.profile.PlatformStringMap;
 import com.ninetwozero.bf4intel.ui.activities.SingleFragmentActivity;
 import com.ninetwozero.bf4intel.utils.BusProvider;
+import com.ninetwozero.bf4intel.utils.PersonaUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,9 +36,6 @@ import java.util.Map;
 
 public class ProfileSearchFragment extends BaseLoadingListFragment {
     public static final String INTENT_QUERY_STRING = "query_string";
-
-    private static final int GAME_ID_BF4 = 2048;
-    private static final int GAME_ID_MOHW = 4096;
 
     private String queryString;
 
@@ -98,14 +96,6 @@ public class ProfileSearchFragment extends BaseLoadingListFragment {
             searchItem.setVisible(true);
         }
     }
-
-    /*
-        Due to Battlelog doing the search by the soldier name (and not the username), we need to
-        get the users that are playing BF4 but not MOHW (gameId >= 2048 && gameId < 4096)
-
-        Info: http://battlelog.battlefield.com/bf4/user/haruhi00/
-        Info: http://battlelog.battlefield.com/bf4/user/cursef (MOHW)
-    */
 
     @Override
     protected void startLoadingData() {
@@ -208,7 +198,7 @@ public class ProfileSearchFragment extends BaseLoadingListFragment {
             Map<Integer, Integer> games = result.getGames();
             for (int platformId : games.keySet()) {
                 final int gameForPlatform = games.get(platformId);
-                if (gameForPlatform >= GAME_ID_BF4 && gameForPlatform < GAME_ID_MOHW) {
+                if (PersonaUtils.isBf4Soldier(gameForPlatform)) {
                     validAccounts.add(
                         new ProfileSearchResult(
                             result.getPersonaId(),

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/utils/PersonaUtils.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/utils/PersonaUtils.java
@@ -3,6 +3,9 @@ package com.ninetwozero.bf4intel.utils;
 import com.ninetwozero.bf4intel.R;
 
 public class PersonaUtils {
+    private static final int GAME_ID_BF4 = 2048;
+    private static final int GAME_ID_MOHW = 4096;
+
     public static String getPlatformNameFromPlatformId(final int id) {
         switch (id) {
             case 0:
@@ -38,5 +41,22 @@ public class PersonaUtils {
             default:
                 return R.drawable.kit_icon_commander;
         }
+    }
+
+    /*
+        Due to Battlelog doing the search by the soldier name (and not the username), we need to
+        get the users that are playing BF4 but not MOHW (gameId >= 2048 && gameId < 4096)
+
+        OR
+
+        gameId >= BF4+MOHW (2048+4096) as PC players "stack up"
+
+        Info: http://battlelog.battlefield.com/bf4/user/haruhi00/
+        Info: http://battlelog.battlefield.com/bf4/user/cursef (MOHW)
+        Info: http://battlelog.battlefield.com/bf4/user/Hyphon (BF4+MOHW on PC)
+    */
+
+    public static boolean isBf4Soldier(int gameId) {
+        return (gameId >= GAME_ID_BF4 && gameId < GAME_ID_MOHW) || (gameId >= GAME_ID_MOHW+GAME_ID_BF4);
     }
 }


### PR DESCRIPTION
Update the BF4 soldier filter to also work with PC edge cases,
ie people that have played both BF4 and MOHW.

As the BF4 and MOHW bitmasks are the highest (2048 and 4096), the
check should be reliable enough for us to do it this way.

@peter-budo 
