### PR TITLE
Add check to prevent showing an existing fragment

### DIFF
--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/base/ui/BaseFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/base/ui/BaseFragment.java
@@ -90,8 +90,10 @@ public abstract class BaseFragment extends Fragment {
             if (fragment == null) {
                 fragment = (DialogFragment) FragmentFactory.get(fragmentType, dataToPass);
             }
-            fragment.show(fragmentManager, tag);
 
+            if (!fragment.isAdded()) {
+                fragment.show(fragmentManager, tag);
+            }
         } else {
             final Intent intent = new Intent(getActivity(), SingleFragmentActivity.class);
             intent.putExtra(SingleFragmentActivity.INTENT_FRAGMENT_TYPE, fragmentType.ordinal());

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/base/ui/BaseListFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/base/ui/BaseListFragment.java
@@ -9,6 +9,7 @@ import android.preference.PreferenceManager;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.ListFragment;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -76,8 +77,10 @@ public abstract class BaseListFragment extends ListFragment {
             if (fragment == null) {
                 fragment = (DialogFragment) FragmentFactory.get(fragmentType, dataToPass);
             }
-            fragment.show(fragmentManager, tag);
 
+            if (!fragment.isAdded()) {
+                fragment.show(fragmentManager, tag);
+            }
         } else {
             final Intent intent = new Intent(getActivity(), SingleFragmentActivity.class);
             intent.putExtra(SingleFragmentActivity.INTENT_FRAGMENT_TYPE, fragmentType.ordinal());


### PR DESCRIPTION
@peter-budo 
Apparently, if you try to show a fragment that has already been added
twice (as `DialogFragment.show(FragmentManager, String)` will try to add
it again), it throws an `IllegalStateException`. This prevents it from
happening.
