### PR TITLE
Do deduplication only once when data are fetched

### DIFF
--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/database/dao/unlocks/kits/KitUnlockMapSorter.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/database/dao/unlocks/kits/KitUnlockMapSorter.java
@@ -13,13 +13,7 @@ import java.util.Set;
 
 public class KitUnlockMapSorter extends AbstractSorter<SortedKitUnlocks> {
     public static final String[] CATEGORY_ORDER = new String[] { "1", "2","32", "8"};
-    private static final Set<String> SKIP_LIST = new HashSet<String>() {
-        {
-            add("1BFBE29D-CA2D-42B8-88DD-8E5C481E40FC"); // AK5C
-            add("D9899D8B-2D67-4A13-975E-F0D5E8E1525D"); // RFB
-            add("9892E6C9-6317-4558-953D-94BA2DCD355C"); // QBS-09
-        }
-    };
+
 
     private Map<String, List<KitItemUnlockContainer>> unlockMap;
 
@@ -30,7 +24,7 @@ public class KitUnlockMapSorter extends AbstractSorter<SortedKitUnlocks> {
     protected SortedKitUnlocks sortByProgress() {
         List<KitItemUnlockContainer> list = new ArrayList<KitItemUnlockContainer>();
         for (String key : unlockMap.keySet()) {
-            final List<KitItemUnlockContainer> allUnlocks = removeDuplicates(unlockMap.get(key));
+            final List<KitItemUnlockContainer> allUnlocks = unlockMap.get(key);
             addKitIdToItems(allUnlocks, key);
             list.addAll(allUnlocks);
         }
@@ -43,7 +37,7 @@ public class KitUnlockMapSorter extends AbstractSorter<SortedKitUnlocks> {
         List<KitItemUnlockContainer> list = new ArrayList<KitItemUnlockContainer>();
         for (String key : CATEGORY_ORDER) {
             if (unlockMap.containsKey(key)) {
-                final List<KitItemUnlockContainer> allUnlocks = removeDuplicates(unlockMap.get(key));
+                final List<KitItemUnlockContainer> allUnlocks = unlockMap.get(key);
                 addKitIdToItems(allUnlocks, key);
                 list.addAll(allUnlocks);
             }
@@ -57,18 +51,5 @@ public class KitUnlockMapSorter extends AbstractSorter<SortedKitUnlocks> {
         }
     }
 
-    private static List<KitItemUnlockContainer> removeDuplicates(final List<KitItemUnlockContainer> containers) {
-        Set<String> guids = new HashSet<String>(SKIP_LIST);
-        List<KitItemUnlockContainer> uniqueList = new ArrayList<KitItemUnlockContainer>();
 
-        for (KitItemUnlockContainer container : containers) {
-            final String guid = container.getUnlock().getGuid();
-            if (guids.contains(guid)) {
-                continue;
-            }
-            guids.add(guid);
-            uniqueList.add(container);
-        }
-        return uniqueList;
-    }
 }

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/services/unlocks/kits/KitUnlockService.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/services/unlocks/kits/KitUnlockService.java
@@ -5,14 +5,29 @@ import com.ninetwozero.bf4intel.database.dao.unlocks.kits.KitUnlockDAO;
 import com.ninetwozero.bf4intel.database.dao.unlocks.kits.KitUnlockMapSorter;
 import com.ninetwozero.bf4intel.events.unlocks.kits.KitUnlocksRefreshedEvent;
 import com.ninetwozero.bf4intel.factories.UrlFactory;
+import com.ninetwozero.bf4intel.json.unlocks.KitItemUnlockContainer;
 import com.ninetwozero.bf4intel.json.unlocks.KitUnlocks;
 import com.ninetwozero.bf4intel.resources.Keys;
 import com.ninetwozero.bf4intel.services.BaseDaoService;
 import com.ninetwozero.bf4intel.ui.unlocks.UnlockTabFragment;
 
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class KitUnlockService extends BaseDaoService<KitUnlockDAO, KitUnlocksRefreshedEvent> {
+    private static final Set<String> SKIP_LIST = new HashSet<String>() {
+        {
+            add("1BFBE29D-CA2D-42B8-88DD-8E5C481E40FC"); // AK5C
+            add("D9899D8B-2D67-4A13-975E-F0D5E8E1525D"); // RFB
+            add("9892E6C9-6317-4558-953D-94BA2DCD355C"); // QBS-09
+        }
+    };
+
     @Override
     protected KitUnlocksRefreshedEvent getEventToBroadcast(boolean result) {
         return new KitUnlocksRefreshedEvent(result);
@@ -21,13 +36,22 @@ public class KitUnlockService extends BaseDaoService<KitUnlockDAO, KitUnlocksRef
     @Override
     protected KitUnlockDAO parseJsonIntoDao(String json) {
         final KitUnlocks unlocks = fromJson(json, KitUnlocks.class);
+        final Map<String, List<KitItemUnlockContainer>> deDuplicatedUnlocks = removeDuplicates(unlocks.getUnlockMap());
         final SortMode sortMode = SortMode.fromOrdinal(sharedPreferences.getInt(UnlockTabFragment.KEY_SORT_MODE, 0));
         return new KitUnlockDAO(
             soldier.getString(Keys.Soldier.ID),
             soldier.getString(Keys.Soldier.NAME),
             soldier.getInt(Keys.Soldier.PLATFORM),
-            new KitUnlockMapSorter(unlocks.getUnlockMap()).sort(sortMode)
+            new KitUnlockMapSorter(deDuplicatedUnlocks).sort(sortMode)
         );
+    }
+
+    private Map<String, List<KitItemUnlockContainer>> removeDuplicates(Map<String, List<KitItemUnlockContainer>> unlocks) {
+        Map<String, List<KitItemUnlockContainer>> unlockMap = new HashMap<String, List<KitItemUnlockContainer>>();
+        for (String key : unlocks.keySet()) {
+            unlockMap.put(key, getUniqueList(unlocks.get(key)));
+        }
+        return unlockMap;
     }
 
     @Override
@@ -37,5 +61,20 @@ public class KitUnlockService extends BaseDaoService<KitUnlockDAO, KitUnlocksRef
             soldier.getString(Keys.Soldier.NAME),
             soldier.getInt(Keys.Soldier.PLATFORM)
         );
+    }
+
+    private static List<KitItemUnlockContainer> getUniqueList(final List<KitItemUnlockContainer> containers) {
+        Set<String> guids = new HashSet<String>(SKIP_LIST);
+        List<KitItemUnlockContainer> uniqueList = new ArrayList<KitItemUnlockContainer>();
+
+        for (KitItemUnlockContainer container : containers) {
+            final String guid = container.getUnlock().getGuid();
+            if (guids.contains(guid)) {
+                continue;
+            }
+            guids.add(guid);
+            uniqueList.add(container);
+        }
+        return uniqueList;
     }
 }

--- a/core/src/main/java/com/ninetwozero/bf4intel/json/unlocks/KitUnlocks.java
+++ b/core/src/main/java/com/ninetwozero/bf4intel/json/unlocks/KitUnlocks.java
@@ -9,6 +9,10 @@ public class KitUnlocks {
     @SerializedName("unlocks")
     private Map<String, List<KitItemUnlockContainer>> unlockMap;
 
+    public KitUnlocks(Map<String, List<KitItemUnlockContainer>> unlockMap){
+        this.unlockMap = unlockMap;
+    }
+
     public Map<String, List<KitItemUnlockContainer>> getUnlockMap() {
         return unlockMap;
     }


### PR DESCRIPTION
@karllindmark 
Just going through PRs I realised there are some similarities between sorters and if we could extract 'removeDuplicates' to somewhere we could actually some core sort functionality shareable between unlocks sorters. So here you go, deduplication done once data fetched from battlelog, it happens only once so it is more efficient then original approach
