### PR TITLE
Do not translate resources

### DIFF
--- a/BF4Intel/build.gradle
+++ b/BF4Intel/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         classpath 'com.crashlytics.tools.gradle:crashlytics-gradle:1.+'
     }
 }
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 apply plugin: 'crashlytics'
 
 project.archivesBaseName = 'com.ninetwozero.bf4intel'

--- a/BF4Intel/src/main/res/values/do_not_translate.xml
+++ b/BF4Intel/src/main/res/values/do_not_translate.xml
@@ -22,4 +22,39 @@
   <string name="label_service_awards">Award Service</string>
   <string name="label_service_battlefeed">Battle Feed Service</string>
   <string name="label_service_news">News Service</string>
+
+  <!--Menu options-->
+  <string name="menu_reset_password">Reset password&#8230;</string>
+  <string name="menu_logout">Logout</string>
+
+  <!-- Login related stuff -->
+  <string name="title_login">Login</string>
+  <string name="action_sign_in_short">Sign in</string>
+  <string name="prompt_email">Origin™ Email</string>
+  <string name="prompt_password">Origin™ Password</string>
+  <string name="login_progress_signing_in">Signing in&#8230;</string>
+  <string name="label_login">Login</string>
+
+  <!--News-->
+  <string name="create_post_header">Post content</string>
+  <string name="create_post_hint">Post message here&#8230;</string>
+  <string name="new_thread_header">Thread title</string>
+  <string name="new_thread_title_hint">When is next patch coming out?</string>
+  <string name="new_thread_content_header">Content</string>
+  <string name="new_thread_content_hint">What is date for new patch</string>
+  <string name="msg_sending">Sending&#8230;</string>
+  <string name="msg_enter_comment">Enter a comment!</string>
+  <string name="msg_comment_ok">Comment posted!</string>
+  <string name="msg_error_gate_redirect">Please login to continue.</string>
+  <string name="msg_error_already_upvoted">You\'ve already hooah\'d this post!</string>
+  <string name="done">Done</string>
+  <string name="label_read">Read</string>
+  <string name="label_discuss">Discuss</string>
+  <string name="label_comment">Comment</string>
+  <string name="hint_comment">Your comment here&#8230;</string>
+  <string name="title_revoke_hooah">Revoke hooah</string>
+  <string name="title_hooah">Hooah</string>
+  <string name="title_unhooah">Un-hooah</string>
+  <string name="msg_user_said_hooah">You said hooah</string>
+  <string name="label_offline_mode">Offline mode</string>
 </resources>

--- a/BF4Intel/src/main/res/values/do_not_translate.xml
+++ b/BF4Intel/src/main/res/values/do_not_translate.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+  <!--Manifest labels-->
+  <string name="label_activity_single_fragment">@string/app_name</string>
+
+  <string name="label_activity_soldier_statistics">STATISTICS</string>
+  <string name="label_activity_assignments">ASSIGNMENTS</string>
+  <string name="label_activity_awards">AWARDS</string>
+  <string name="label_activity_unlocks">UNLOCKS</string>
+  <string name="label_search">Search</string>
+
+  <string name="label_service_soldieroverview">Soldier Overview Service</string>
+  <string name="label_service_stats_weapons">Weapon Stats Service</string>
+  <string name="label_service_stats_vehicles">Vehicle Stats Service</string>
+  <string name="label_service_stats_reports">Reports Stats Service</string>
+  <string name="label_service_stats_details">Detailed Stats Service</string>
+  <string name="label_service_unlocks_weapons">Weapon Unlocks Service</string>
+  <string name="label_service_unlocks_vehicles">Vehicle Unlocks Service</string>
+  <string name="label_service_unlocks_kits">Kit Unlocks Service</string>
+  <string name="label_service_assignments">Assignment Service</string>
+  <string name="label_service_awards">Award Service</string>
+  <string name="label_service_battlefeed">Battle Feed Service</string>
+  <string name="label_service_news">News Service</string>
+</resources>

--- a/BF4Intel/src/main/res/values/strings.xml
+++ b/BF4Intel/src/main/res/values/strings.xml
@@ -5,26 +5,6 @@
 
   <string name="app_name">BF4 Intel</string>
 
-  <!--Manifest labels-->
-  <string name="label_activity_single_fragment">@string/app_name</string>
-  <string name="label_activity_soldier_statistics">STATISTICS</string>
-  <string name="label_activity_assignments">ASSIGNMENTS</string>
-  <string name="label_activity_awards">AWARDS</string>
-  <string name="label_activity_unlocks">UNLOCKS</string>
-  <string name="label_search">Search</string>
-  <string name="label_service_soldieroverview">Soldier Overview Service</string>
-  <string name="label_service_stats_weapons">Weapon Stats Service</string>
-  <string name="label_service_stats_vehicles">Vehicle Stats Service</string>
-  <string name="label_service_stats_reports">Reports Stats Service</string>
-  <string name="label_service_stats_details">Detailed Stats Service</string>
-  <string name="label_service_unlocks_weapons">Weapon Unlocks Service</string>
-  <string name="label_service_unlocks_vehicles">Vehicle Unlocks Service</string>
-  <string name="label_service_unlocks_kits">Kit Unlocks Service</string>
-  <string name="label_service_assignments">Assignment Service</string>
-  <string name="label_service_awards">Award Service</string>
-  <string name="label_service_battlefeed">Battle Feed Service</string>
-  <string name="label_service_news">News Service</string>
-
   <!--Navigation drawer-->
   <string name="navigationdrawer_selected_soldier">Selected soldier</string>
   <string name="navigationdrawer_my_soldier">My soldier</string>

--- a/BF4Intel/src/main/res/values/strings.xml
+++ b/BF4Intel/src/main/res/values/strings.xml
@@ -25,12 +25,14 @@
   <string name="menu_settings">Settings</string>
   <string name="menu_title_sort">Sort</string>
   <string name="menu_title_filter">Filter</string>
-  <string name="menu_reset_password">Reset password&#8230;</string>
-  <string name="menu_logout">Logout</string>
   <string name="ab_action_send">Send</string>
+  <string name="filter_more_options">More options</string>
+  <string name="label_sort_all">Show all</string>
+  <string name="label_sort_categorized">Select category</string>
+  <string name="label_sort_progress">By progress</string>
+
 
   <!-- HEADINGS -->
-  <string name="filter_more_options">More options</string>
   <string name="weapons">Weapons</string>
   <string name="vehicles">Vehicles</string>
   <string name="reports">Reports</string>
@@ -83,6 +85,30 @@
   <string name="skills_time">Time</string>
   <string name="kill_a_minute">K/Min</string>
 
+  <!--Weapon details-->
+  <string name="label_information">Information</string>
+  <string name="damage">Damage</string>
+  <string name="hip_fire">Hip Fire</string>
+  <string name="range">Range</string>
+  <string name="fire_modes">Fire Modes</string>
+  <string name="fire_mode_single">Single</string>
+  <string name="fire_mode_burst">Burst</string>
+  <string name="fire_mode_auto">Auto</string>
+  <string name="kills_per_shot">Kills per shot</string>
+  <string name="time_equipped">Time equipped</string>
+  <string name="rate_of_fire">Rate of fire</string>
+  <string name="label_description">Description</string>
+  <string name="stat_item_title">%1$s. %2$s</string>
+
+  <!--Awards & assignments details-->
+  <string name="label_completed">Completed</string>
+  <string name="assignment_prerequisite">Pre-requisites</string>
+  <string name="assignment_requirements">Award Requirements</string>
+  <string name="assignment_reward">Reward</string>
+  <string name="label_viewing">Viewing %s</string>
+  <string name="label_in_a_round">In a round</string>
+  <string name="award_available">Available in&#160;</string> <!--&#160; stands for empty space-->
+
   <!-- Battle reports -->
   <string name="battlereport_time">Duration:</string>
   <string name="msg_no_battlereports">No Battle Reports found.</string>
@@ -131,14 +157,8 @@
   <string name="home_select_another_account">Change account</string>
   <string name="action_search_short">Search</string>
   <string name="msg_search_error_length">Min length: 3 characters</string>
-  <string name="title_login">Login</string>
-  <string name="action_sign_in_short">Sign in</string>
-  <string name="prompt_email">Origin™ Email</string>
-  <string name="prompt_password">Origin™ Password</string>
   <string name="msg_no_network">This feature requires Internet access.</string>
   <string name="msg_unable_to_refresh">This feature requires Internet access.</string>
-  <string name="login_progress_signing_in">Signing in&#8230;</string>
-  <string name="label_login">Login</string>
   <string name="msg_downloading">Downloading information&#8230;</string>
   <string name="msg_no_users_found">No users found.</string>
   <string name="hint_search">Search for users</string>
@@ -161,6 +181,12 @@
   <string name="msg_error_not_found">Resource not found.</string>
   <string name="msg_empty_news">No news found.</string>
   <string name="text_divider">|</string>
+  <string name="num_hooahs">%1$s hooahs</string>
+  <string name="num_comments">%1$s comments</string>
+
+  <!--Settings text-->
+  <string name="settings_title_user_in_crash_report">Send username in crash log</string>
+  <string name="settings_summary_user_in_crash_report">By keeping this option checked you are helping us to reproduce and solve reported issues faster.</string>
 
   <!--Generic used in various places of app-->
   <string name="unknown">Unknown</string>
@@ -170,57 +196,6 @@
   <string name="label_share">Share</string>
   <string name="toast_unimplemented_functionality">Unimplemented functionality.</string>
   <string name="toast_please_log_in">@string/toast_unimplemented_functionality</string>  <!-- TODO: Will replace with login message once login available-->
-  <string name="award_available">Available in&#160;</string> <!--&#160; stands for empty space-->
 
-  <string name="create_post_header">Post content</string>
-  <string name="create_post_hint">Post message here&#8230;</string>
-  <string name="new_thread_header">Thread title</string>
-  <string name="new_thread_title_hint">When is next patch coming out?</string>
-  <string name="new_thread_content_header">Content</string>
-  <string name="new_thread_content_hint">What is date for new patch</string>
-  <string name="msg_empty_comments">No comments found.</string>
-  <string name="msg_sending">Sending&#8230;</string>
-  <string name="msg_enter_comment">Enter a comment!</string>
-  <string name="msg_comment_ok">Comment posted!</string>
-  <string name="msg_error_gate_redirect">Please login to continue.</string>
-  <string name="msg_error_already_upvoted">You\'ve already hooah\'d this post!</string>
-  <string name="done">Done</string>
-  <string name="label_read">Read</string>
-  <string name="label_discuss">Discuss</string>
-  <string name="label_comment">Comment</string>
-  <string name="hint_comment">Your comment here&#8230;</string>
-  <string name="num_hooahs">%1$s hooahs</string>
-  <string name="num_comments">%1$s comments</string>
-  <string name="title_revoke_hooah">Revoke hooah</string>
-  <string name="title_hooah">Hooah</string>
-  <string name="title_unhooah">Un-hooah</string>
-  <string name="msg_user_said_hooah">You said hooah</string>
-  <string name="label_sort_all">Show all</string>
-  <string name="label_sort_categorized">Select category</string>
-  <string name="label_sort_progress">By progress</string>
-  <string name="label_completed">Completed</string>
-  <string name="label_offline_mode">Offline mode</string>
-  <string name="assignment_prerequisite">Pre-requisites</string>
-  <string name="assignment_requirements">Award Requirements</string>
-  <string name="assignment_reward">Reward</string>
-  <string name="label_viewing">Viewing %s</string>
-  <string name="label_in_a_round">In a round</string>
 
-  <string name="label_information">Information</string>
-  <string name="damage">Damage</string>
-  <string name="hip_fire">Hip Fire</string>
-  <string name="range">Range</string>
-  <string name="fire_modes">Fire Modes</string>
-  <string name="fire_mode_single">Single</string>
-  <string name="fire_mode_burst">Burst</string>
-  <string name="fire_mode_auto">Auto</string>
-  <string name="kills_per_shot">Kills per shot</string>
-  <string name="time_equipped">Time equipped</string>
-  <string name="rate_of_fire">Rate of fire</string>
-  <string name="label_description">Description</string>
-  <string name="stat_item_title">%1$s. %2$s</string>
-  <string name="team">Team</string>
-
-  <string name="settings_title_user_in_crash_report">Send username in crash log</string>
-  <string name="settings_summary_user_in_crash_report">By keeping this option checked you are helping us to reproduce and solve reported issues faster.</string>
 </resources>


### PR DESCRIPTION
@karllindmark 

I was doing some translations on Monday evening and realised that some of the strings do not really require translations either due to the fact that stuff is not implemented or because it is app internal stuff that does not affects user experience (example service labels from manifest).

When this is merged can you please check/exclude do_not_translate.xml from getlocalization?

Also PR includes fix for android plugin name change from `android` to `com.android.application`
