### PR TITLE
build tools update

### DIFF
--- a/BF4Intel/build.gradle
+++ b/BF4Intel/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url 'http://download.crashlytics.com/maven' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.2'
+        classpath 'com.android.tools.build:gradle:0.13.1'
         classpath 'com.crashlytics.tools.gradle:crashlytics-gradle:1.+'
     }
 }


### PR DESCRIPTION
@karllindmark 

Updated Android Gradle plugin to 0.13.1 to support Gradle 2.1, this also requires update to Android Studio 0.8.11
