### PR TITLE
Fix empty view cast

### DIFF
--- a/BF4Intel/src/main/assets/changelog.htm
+++ b/BF4Intel/src/main/assets/changelog.htm
@@ -41,6 +41,16 @@
     </style>
 </head>
 <body>
+<h1 class="group-header">Version 1.0.5</h1>
+<article>
+    <ul>
+        <li>Fixed issue where application would crash on search. Sorry for inconvenience, this was
+            introduced with pull to refresh functionality.
+        </li>
+        <li></li>
+        <li></li>
+    </ul>
+</article>
 <h1 class="group-header">Version 1.0.4</h1>
 <article>
     <ul>

--- a/BF4Intel/src/main/assets/changelog.htm
+++ b/BF4Intel/src/main/assets/changelog.htm
@@ -47,8 +47,6 @@
         <li>Fixed issue where application would crash on search. Sorry for inconvenience, this was
             introduced with pull to refresh functionality.
         </li>
-        <li></li>
-        <li></li>
     </ul>
 </article>
 <h1 class="group-header">Version 1.0.4</h1>

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/search/ProfileSearchFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/search/ProfileSearchFragment.java
@@ -12,7 +12,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AbsListView;
 import android.widget.ListView;
-import android.widget.TextView;
 
 import com.android.volley.Request;
 import com.ninetwozero.bf4intel.Bf4Intel;
@@ -220,8 +219,8 @@ public class ProfileSearchFragment extends BaseLoadingListFragment {
         }
 
         if (results.isEmpty()) {
-            final TextView emptyTextView = (TextView) getView().findViewById(android.R.id.empty);
-            emptyTextView.setText(R.string.msg_no_users_found);
+            setCustomEmptyText(getView(), R.string.msg_no_users_found);
+            getView().findViewById(R.id.logo).setVisibility(View.GONE);
         }
 
         ProfileSearchAdapter adapter = (ProfileSearchAdapter) getListAdapter();


### PR DESCRIPTION
@karllindmark 

Fixed crash when user search would return no results and casting "No user found" would cause app to crash because of custom empty text.

I suggest to push this as emergency release as number of crashes is 230 and counting since release
