### PR TITLE
Bugfix/assignment detail single player

### DIFF
--- a/BF4Intel/build.gradle
+++ b/BF4Intel/build.gradle
@@ -17,8 +17,8 @@ android {
 
     defaultConfig {
         applicationId 'com.ninetwozero.bf4intel'
-        versionCode 1614120
-        versionName '1.2.0'
+        versionCode 1614121
+        versionName '1.2.1'
         minSdkVersion 14
         targetSdkVersion 25
     }

--- a/BF4Intel/src/main/assets/changelog.htm
+++ b/BF4Intel/src/main/assets/changelog.htm
@@ -41,6 +41,14 @@
     </style>
 </head>
 <body>
+<h1 class="group-header">Version 1.2.1</h1>
+<article>
+    <ul>
+        <li>Fixed crash when user try to view assignment details of single player assignments</li>
+        <li>Fixed crash if user viewing AWARDS screen tap on sort of filter icon before data are loaded on screen</li>
+        <li>Fixed crash when viewing NEWS and server doesn't returns any results. User will is presented with message to try later</li>
+    </ul>
+</article>
 <h1 class="group-header">Version 1.2.0</h1>
 <article>
     <ul>

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/assignments/AssignmentDetailFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/assignments/AssignmentDetailFragment.java
@@ -181,7 +181,7 @@ public class AssignmentDetailFragment extends BaseDialogFragment {
             final boolean isInRoundRequirement = "CriteriaType_IAR_InARound".equals(criteria.getCriteriaType());
 
             setText(tempView, R.id.task_label, AssignmentCriteriaStringMap.get(criteria.getKey()));
-            if(assignment.getAward().getAwardCriterias() != null) { //User updated data nad have new AwardsCriterias object
+            if(assignment.getAward().getAwardCriterias() != null && !assignment.getAward().getAwardCriterias().isEmpty()) { //User updated data nad have new AwardsCriterias object
                 setText(tempView, R.id.task_completion, getTaskCompletionString(criteria.getCurrentValue(), assignment.getAward().getAwardCriterias().get(i).getCompletionValue()));
             } else {//User is still on old data so use old format
                 setText(tempView, R.id.task_completion, getTaskCompletionString(criteria));

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/awards/AwardGridFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/awards/AwardGridFragment.java
@@ -121,14 +121,16 @@ public class AwardGridFragment
         final View emptyView = view.findViewById(android.R.id.empty);
         setCustomEmptyText(emptyView, R.string.empty_text_awards);
 
-        final GridView gridView = (GridView) view.findViewById(R.id.assignments_grid);
+        gridView = (GridView) view.findViewById(R.id.assignments_grid);
         gridView.setOnItemClickListener(this);
         gridView.setEmptyView(emptyView);
 
     }
 
     private void sendDataToGridView(final View view, List<Award> awards) {
-        gridView = (GridView) view.findViewById(R.id.assignments_grid);
+        if(gridView == null) {
+            gridView = (GridView) view.findViewById(R.id.assignments_grid);
+        }
         AwardsAdapter adapter = (AwardsAdapter) gridView.getAdapter();
         if (adapter == null) {
             adapter = new AwardsAdapter(getActivity());

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/news/NewsListingFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/news/NewsListingFragment.java
@@ -6,6 +6,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ListView;
+import android.widget.Toast;
 
 import com.android.volley.VolleyError;
 import com.ninetwozero.bf4intel.Bf4Intel;
@@ -21,6 +22,8 @@ import com.ninetwozero.bf4intel.ui.menu.RefreshEvent;
 import com.squareup.otto.Subscribe;
 
 import java.util.List;
+
+import javax.xml.datatype.Duration;
 
 public class NewsListingFragment extends BaseLoadingListFragment {
     public static final String ID = "articleId";
@@ -84,7 +87,11 @@ public class NewsListingFragment extends BaseLoadingListFragment {
     @Subscribe
     @SuppressWarnings("unused")
     public void onNewsRefreshed(NewsListingRefreshedEvent response) {
-        sendItemsToListView(response.getRequest().getArticles());
+        if (response.getRequest() != null && response.getRequest().getArticles() != null) {
+            sendItemsToListView(response.getRequest().getArticles());
+        } else {
+            Toast.makeText(getContext(), "Failed to load latest new, please try later.", Toast.LENGTH_LONG).show();
+        }
         showLoadingState(false);
         isReloading = false;
     }

--- a/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/news/NewsListingFragment.java
+++ b/BF4Intel/src/main/java/com/ninetwozero/bf4intel/ui/news/NewsListingFragment.java
@@ -23,8 +23,6 @@ import com.squareup.otto.Subscribe;
 
 import java.util.List;
 
-import javax.xml.datatype.Duration;
-
 public class NewsListingFragment extends BaseLoadingListFragment {
     public static final String ID = "articleId";
 


### PR DESCRIPTION
- Fixes #189 crash when user try to view assignment details of single player assignments
- Fixed crash if user viewing AWARDS screen tap on sort of filter icon before data are loaded on screen
- Fixed crash when viewing NEWS and server doesn't returns any results. User will is presented with message to try later